### PR TITLE
Fix issue #40: Migrated from URLSession to Alamofire lib.

### DIFF
--- a/DiveLane.xcodeproj/project.pbxproj
+++ b/DiveLane.xcodeproj/project.pbxproj
@@ -934,6 +934,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-DiveLane/Pods-DiveLane-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/BigInt/BigInt.framework",
 				"${BUILT_PRODUCTS_DIR}/CryptoSwift/CryptoSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/PromiseKit/PromiseKit.framework",
@@ -946,6 +947,7 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BigInt.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CryptoSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PromiseKit.framework",

--- a/DiveLane/Service Layer/TokensService.swift
+++ b/DiveLane/Service Layer/TokensService.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import web3swift
+import Alamofire
 import struct BigInt.BigUInt
 
 protocol ITokensService {
@@ -164,29 +165,31 @@ class TokensService {
             return
         }
 
-        let task = URLSession.shared.dataTask(with: url) { (data, _, error) in
-            if let data = data {
-                do {
-                    if let jsonSerialized = try JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] {
-                        let dictsCount = jsonSerialized.count
-                        var counter = 0
-                        try jsonSerialized.forEach({ (dict) in
-                            counter += 1
-                            LocalDatabase().saveToken(from: dict, completion: { (_) in
-                                if counter == dictsCount {
-                                    completion(nil)
-                                }
-                            })
-                        })
-                    }
-                } catch {
-                    completion(error)
-                }
-            } else {
-                completion(error)
-            }
-        }
-        task.resume()
+		Alamofire.request(url).responseJSON { response in
+			guard response.result.isSuccess else {
+				completion(response.result.error!)
+				return
+			}
+
+			guard response.data != nil else {
+				completion(response.result.error!)
+				return
+			}
+				guard let value = response.result.value as? [[String: Any]] else {
+					completion(response.result.error!)
+					return
+				}
+				let dictsCount = value.count
+				var counter = 0
+				value.forEach({ (dict) in
+					counter += 1
+					LocalDatabase().saveToken(from: dict, completion: {(_) in
+						if counter == dictsCount {
+							completion(nil)
+						}
+					})
+				})
+		}
     }
 
     func updateConversion(for token: ERC20TokenModel, completion: @escaping (Double?) -> Void) {

--- a/DiveLane/Service Layer/TransactionsHistoryService.swift
+++ b/DiveLane/Service Layer/TransactionsHistoryService.swift
@@ -9,6 +9,7 @@
 import Foundation
 import web3swift
 import BigInt
+import Alamofire
 
 class TransactionsHistoryService {
     func loadTransactions(forAddress address: String, type: TransactionType, inNetwork networkId: Int64, completion: @escaping(Result<[ETHTransactionModel]>) -> Void) {
@@ -16,87 +17,76 @@ class TransactionsHistoryService {
             completion(Result.Error(NetworkErrors.couldnotParseUrlString))
             return
         }
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        let dataTask = URLSession.shared.dataTask(with: request) { (data, _, error) in
-            if let error = error {
-                DispatchQueue.main.async {
-                    completion(Result.Error(error))
-                }
-                return
-            }
-            guard let data = data else {
-                DispatchQueue.main.async {
-                    completion(Result.Error(NetworkErrors.couldnotParseJSON))
-                }
-                return
-            }
-            do {
-                guard let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
-                    DispatchQueue.main.async {
-                        completion(Result.Error(NetworkErrors.couldnotParseJSON))
-                    }
-                    return
-                }
-                guard let results = json["result"] as? [[String: Any]] else {
-                    DispatchQueue.main.async {
-                        completion(Result.Error(NetworkErrors.couldnotParseJSON))
-                    }
-                    return
-                }
-                var transactions = [ETHTransactionModel]()
-                for result in results {
-                    guard let from = result["from"] as? String,
-                          let to = result["to"] as? String,
-                          let timestamp = Double((result["timeStamp"] as? String)!),
-                          let value = result["value"] as? String,
-                          let hash = result["hash"] as? String,
-                          let data = result["input"] as? String else {
-                        DispatchQueue.main.async {
-                            completion(Result.Error(NetworkErrors.couldnotParseJSON))
-                        }
-                        return
-                    }
-                    let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
-                    var tokenModel: ERC20TokenModel?
-                    if type == .arbitraryMethodWithParams {
-                        guard let tokenName = result["tokenName"] as? String,
-                              let tokenSymbol = result["tokenSymbol"] as? String,
-                              let tokenDecimal = result["tokenDecimal"] as? String,
-                              let tokenAddress = result["contractAddress"] as? String else {
-                            return
-                        }
-                        tokenModel = ERC20TokenModel(name: tokenName, address: tokenAddress, decimals: tokenDecimal, symbol: tokenSymbol)
-                    } else {
-                        tokenModel = nil
-                    }
-                    guard let amount = BigUInt(value) else {
-                        return
-                    }
-                    guard let amountString = Web3.Utils.formatToEthereumUnits(amount) else {
-                        return
-                    }
-                    let transaction = ETHTransactionModel(transactionHash: hash,
-                                                          from: from,
-                                                          to: to,
-                                                          amount: amountString,
-                                                          date: date,
-                                                          data: Data.fromHex(data),
-                                                          token: tokenModel,
-                                                          networkID: networkId,
-                                                          isPending: false)
-                    transactions.append(transaction)
-                }
-                DispatchQueue.main.async {
-                    completion(Result.Success(transactions))
-                }
-            } catch {
-                DispatchQueue.main.async {
-                    completion(Result.Error(error))
-                }
-            }
-        }
-        dataTask.resume()
+
+		Alamofire.request(url, method: .get).responseJSON { response in
+			guard response.result.isSuccess else {
+				DispatchQueue.main.async {
+					completion(Result.Error(response.result.error!))
+				}
+				return
+			}
+
+			guard response.data != nil else {
+				DispatchQueue.main.async {
+					completion(Result.Error(NetworkErrors.couldnotParseJSON))
+				}
+				return
+			}
+
+			guard let value = response.result.value as? [String: Any],
+			let results = value["result"] as? [[String: Any]] else {
+				DispatchQueue.main.async {
+					completion(Result.Error(NetworkErrors.couldnotParseJSON))
+				}
+				return
+			}
+			var transactions = [ETHTransactionModel]()
+			for result in results {
+				guard let from = result["from"] as? String,
+					let to = result["to"] as? String,
+					let timestamp = Double((result["timeStamp"] as? String)!),
+					let value = result["value"] as? String,
+					let hash = result["hash"] as? String,
+					let data = result["input"] as? String else {
+						DispatchQueue.main.async {
+							completion(Result.Error(NetworkErrors.couldnotParseJSON))
+						}
+						return
+				}
+				let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+				var tokenModel: ERC20TokenModel?
+				if type == .arbitraryMethodWithParams {
+					guard let tokenName = result["tokenName"] as? String,
+						let tokenSymbol = result["tokenSymbol"] as? String,
+						let tokenDecimal = result["tokenDecimal"] as? String,
+						let tokenAddress = result["contractAddress"] as? String else {
+							return
+					}
+					tokenModel = ERC20TokenModel(name: tokenName, address: tokenAddress, decimals: tokenDecimal, symbol: tokenSymbol)
+				} else {
+					tokenModel = nil
+				}
+				guard let amount = BigUInt(value) else {
+					return
+				}
+				guard let amountString = Web3.Utils.formatToEthereumUnits(amount) else {
+					return
+				}
+				let transaction = ETHTransactionModel(transactionHash: hash,
+													  from: from,
+													  to: to,
+													  amount: amountString,
+													  date: date,
+													  data: Data.fromHex(data),
+													  token: tokenModel,
+													  networkID: networkId,
+													  isPending: false)
+				transactions.append(transaction)
+			}
+			DispatchQueue.main.async {
+				completion(Result.Success(transactions))
+			}
+		}
     }
 
 }

--- a/Podfile
+++ b/Podfile
@@ -9,5 +9,6 @@ target 'DiveLane' do
   pod 'QRCodeReader.swift', '~> 8.1.1'
   pod 'Fabric'
   pod 'Crashlytics'
+  pod 'Alamofire', '~> 4.7'
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - Alamofire (4.7.3)
   - BigInt (3.1.0):
     - SipHash (~> 1.2)
   - Crashlytics (3.10.7):
@@ -29,6 +30,7 @@ PODS:
     - secp256k1_ios (~> 0.1)
 
 DEPENDENCIES:
+  - Alamofire (~> 4.7)
   - Crashlytics
   - Fabric
   - QRCodeReader.swift (~> 8.1.1)
@@ -36,6 +38,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
+    - Alamofire
     - BigInt
     - Crashlytics
     - CryptoSwift
@@ -58,6 +61,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/matterinc/web3swift
 
 SPEC CHECKSUMS:
+  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   BigInt: 76b5dfdfa3e2e478d4ffdf161aeede5502e2742f
   Crashlytics: ccaac42660eb9351b9960c0d66106b0bcf99f4fa
   CryptoSwift: 1c07ca50843dd48bc54e6ea53d7a4dba3b645716
@@ -70,6 +74,6 @@ SPEC CHECKSUMS:
   SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
   web3swift: 4895c765c9858eb4737ef222eb8643bb5fc7fdb3
 
-PODFILE CHECKSUM: 2a44e707a6c54f6da8a803adbc9e488b1ce1a334
+PODFILE CHECKSUM: a0a81a132c8eb903458653bc3fb8d38f4f1026ec
 
 COCOAPODS: 1.5.3

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,4 +1,5 @@
 PODS:
+  - Alamofire (4.7.3)
   - BigInt (3.1.0):
     - SipHash (~> 1.2)
   - Crashlytics (3.10.7):
@@ -29,6 +30,7 @@ PODS:
     - secp256k1_ios (~> 0.1)
 
 DEPENDENCIES:
+  - Alamofire (~> 4.7)
   - Crashlytics
   - Fabric
   - QRCodeReader.swift (~> 8.1.1)
@@ -36,6 +38,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
+    - Alamofire
     - BigInt
     - Crashlytics
     - CryptoSwift
@@ -58,6 +61,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/matterinc/web3swift
 
 SPEC CHECKSUMS:
+  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   BigInt: 76b5dfdfa3e2e478d4ffdf161aeede5502e2742f
   Crashlytics: ccaac42660eb9351b9960c0d66106b0bcf99f4fa
   CryptoSwift: 1c07ca50843dd48bc54e6ea53d7a4dba3b645716
@@ -70,6 +74,6 @@ SPEC CHECKSUMS:
   SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
   web3swift: 4895c765c9858eb4737ef222eb8643bb5fc7fdb3
 
-PODFILE CHECKSUM: 2a44e707a6c54f6da8a803adbc9e488b1ce1a334
+PODFILE CHECKSUM: a0a81a132c8eb903458653bc3fb8d38f4f1026ec
 
 COCOAPODS: 1.5.3

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,437 +7,478 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		02E8046C2A767EA8848448EAB9E07A65 /* DigestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE6F70BF47E8B23A975E5B8605326AB /* DigestType.swift */; };
-		036DD11987B19189CB4D3F7D5C2E8362 /* Pods-DiveLane-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 52EA56A9EF83E4CC6F7B02F5D1878DB7 /* Pods-DiveLane-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		03FA8EDEAAF28C2F20B6134374C42DAB /* SipHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922C288F68253A0F8165786CEEDC1634 /* SipHashable.swift */; };
-		04006266093ACBC0A638A0142C4D1AF6 /* NativeTypesEncoding+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8CCF59177FA9414B4E01275FA4B5B5 /* NativeTypesEncoding+Extensions.swift */; };
-		063172677A7320FA0176B8142D11805E /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1704372B6C03EF041EA1BFCBABD488C4 /* Authenticator.swift */; };
-		0717ACAE7ECC2E7D2E33FEEB38A76E2F /* SHA3.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A9342EAD85D9110FF0B04FCF37DA4F /* SHA3.swift */; };
-		0717C597991F5FBC8CE91AD8636AC665 /* Web3+Personal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E539160B76CACFD6BA902BA856B30B06 /* Web3+Personal.swift */; };
-		0732B277DE0821A2E9F30FD82A2D505C /* SHA2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495C0ADF7FE8768DC36EE0D4CCF706BB /* SHA2.swift */; };
-		07A516E5DC61219A239FE2E3E902E691 /* ECB.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8AE5D5F696161490EDCAAB4F1337C16 /* ECB.swift */; };
-		088387733523D1CAFA7D4DC267EA4433 /* Strideable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2096C189F0562355E3A36E1297CE4C80 /* Strideable.swift */; };
-		08DB593EDADE2DD7883C29B717618E39 /* QRCodeReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EE51E952189926295F6C68F96A5523 /* QRCodeReaderView.swift */; };
-		09648EACD312EC7080BB4E2CD9B0943F /* CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59FCF5E84197D2A24E0AAEA2AC41BAB /* CBC.swift */; };
-		0A87671A3BA0E230C5A2929DDF10585D /* ecmult_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = FC852AFAFDAF21F5CDC00B08C2C9A229 /* ecmult_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0AECF16DDD9CAC98AC49FE7EF5FC85F4 /* afterlife.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467FBA75EB54C769E993036F93727FE5 /* afterlife.swift */; };
-		0B0BC8ECFE3E0D034F09A45BA825E43B /* scrypt-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 831D4E4706C7D1131BA808C8CC6B2407 /* scrypt-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0C8972E301C7F4F94D106F25C85FFC80 /* Cimpl.c in Sources */ = {isa = PBXBuildFile; fileRef = CF68056D625032F4519B4087C11B8241 /* Cimpl.c */; };
-		0FA7E1ED09D6CB457D8B1F5880A97CEB /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3301B9C2C1C3E440033DF99B705DA5FD /* Data+Extension.swift */; };
-		0FEB4BA2D6EE420C6B205CA6493C6E43 /* Web3+Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A29D991D251FA407E8574127CB40CE3 /* Web3+Wallet.swift */; };
-		101CEC15F6F283289721E6DA1640B5DB /* AES.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6FCDEC38554B2B6C697FE4E71B357F /* AES.swift */; };
-		11155D066240AA9BCB5FB19A8915C253 /* GCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73CBF28A681EF4CB1AC90E2E10A0E26 /* GCD.swift */; };
-		1374D153A4DF11A93393A7EB31034589 /* num_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = CA7B4CE9C4365DCA0228DF681C4E2948 /* num_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		13EAB80B4DDBD51BA7416B5334398697 /* QRCodeReaderResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEEC3EBA384B1DDF7CE41B1E9B2E753 /* QRCodeReaderResult.swift */; };
-		160FDDA9DD8EE18EB07873303FA53AE8 /* Cimpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F63C1B9F2BDF4747B7CBE35E7A0563A /* Cimpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1683DAE42C36CCB9ECE24588628B039E /* Web3+TransactionIntermediate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F823FDD38A4551CF9D48F30E8B333E78 /* Web3+TransactionIntermediate.swift */; };
-		17F13BC4520B04F0B4FBC069AE4E4A6D /* field.h in Headers */ = {isa = PBXBuildFile; fileRef = 5315E4C0E16806FBD1FEE84852B9A530 /* field.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		19B0977DB29904E6DE638F5373A9B54A /* web3swift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C8F8375B636A25054B8B6C8A00DAE0 /* web3swift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1AB4A0A4A8A746C9B892D15E445A3389 /* dispatch_promise.m in Sources */ = {isa = PBXBuildFile; fileRef = 53DBFB7B72D0AEA4C3DFC83B0D922333 /* dispatch_promise.m */; };
-		1B924C2342742E52ECF00A6DCABCBB37 /* NSURLSession+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = F50E53C4909EEB420176F673A114DC38 /* NSURLSession+AnyPromise.m */; };
-		1BCB9DD16356988A63930EE16C54EB64 /* secp256k1.c in Sources */ = {isa = PBXBuildFile; fileRef = AE2F6C3989B7DC36E54BF9F72856E6F1 /* secp256k1.c */; };
-		1BD471AEF71B89434B36F63FF9CA4064 /* Pods-DiveLane-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 664AEC560E1890D2ACDBD5C818D02E07 /* Pods-DiveLane-dummy.m */; };
-		1C1237D0FB45A6ECDE25172AF2878F8F /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2D8F9E8F18C8FE7181B08A0B71CA1A1 /* after.swift */; };
-		1C53AF4113DA6608A4B207AFF139039A /* RandomUInt64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF0A2349580453266D55F969B32F05B /* RandomUInt64.swift */; };
-		1C6305612C71BA4A41EA3EE86EF9DE98 /* Addition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B66623F19008617D078D938B35FA5E /* Addition.swift */; };
-		1D18F2ACBCAEBB8A02EC4133AE07F517 /* Web3+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A737611902B285FF9F052CF2E61EFF8 /* Web3+ObjC.swift */; };
-		1D66060E38DEFB248D31C71742F0C23E /* QRCodeReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD0605F39212C4B999DCEC974A04FD8 /* QRCodeReader.swift */; };
-		1EED58F062A3C4CD640300B780F23434 /* BigUInt+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30556C7671D0B1E8F19FB68CFBF69F91 /* BigUInt+ObjC.swift */; };
-		1F0FFD9E2ECAC11C485C531C9E5172CC /* scalar_8x32_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BCE86301701700B88CD7D4A5D2F8AD8 /* scalar_8x32_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1F4BDDA00F127CA95F0BFC9F034BD28D /* ChaCha20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D1A77434D0B4FEE3D3DE61CF971BAA /* ChaCha20.swift */; };
-		1F522B047157244684FC7A469A5654D5 /* BlockMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEA9371FBA0B1B3B64B73679B9ED051 /* BlockMode.swift */; };
-		1F659F98C15E25C3A72D24E71FD3A7BC /* EthereumTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886A1282A062E66825671DF657D44E64 /* EthereumTransaction.swift */; };
-		1FE37F8E4D182DBDC8C4F30AFD4757B4 /* PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 52242637417D88569D291E75739F18F0 /* PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2058A726DD078C04D63E243565CD07E1 /* BatchedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4EDAD930B01C250C0F748F8CA2C7CC /* BatchedCollection.swift */; };
-		20A72431C84CF630A969A52D154F717A /* UIView+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = B30A1A7519934D9C2130711A3D73EA88 /* UIView+AnyPromise.m */; };
-		22FE67B665841A937E8D95D9DBCC7EB7 /* Bitwise Ops.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5617684FF7E52B38B69C71ADE69269D /* Bitwise Ops.swift */; };
-		231D94F4178EAA364509D93CCD051CE1 /* PMKFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 9914D1F2AE3E2341EE53A6C12D075E42 /* PMKFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		23E69E19A1E45A210A051F28FBDF4279 /* Checksum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050032CBDB96B47020EE0C79B908B9D4 /* Checksum.swift */; };
-		258BAACBB50FF93C7571AC4C3BE71BD7 /* ecmult_const.h in Headers */ = {isa = PBXBuildFile; fileRef = 644FF28E462665CF8CCAD2B89260E2AB /* ecmult_const.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2631A7A57C311AA166F1E8ACDABCEBBF /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13689EA7380E49B83A5D99C87E16871 /* CustomStringConvertible.swift */; };
-		26CEEDFAC3FD4DFAD1D9C63E838DE21F /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111B1E010967857A74EF10904989919 /* Result.swift */; };
-		273757501A417D274C80593F160D6339 /* scratch.h in Headers */ = {isa = PBXBuildFile; fileRef = 2820F060E279253421A0C56DAA72D99C /* scratch.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		288250141FA353726E30472933B3E9DC /* Prime Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = D439BB66554D1352661D93A5B8DCC2CD /* Prime Test.swift */; };
-		2938FF66785FC4AE2B3ED4EE1553D10E /* CryptoExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA7456076875720004B445B49676E91 /* CryptoExtensions.swift */; };
-		2B9040CE8F9995FE8E8EAA5022B33E95 /* num_gmp_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C551C86FF3B824BF8A787414B675472 /* num_gmp_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2BCA931010327B7616D84860C4E8DE2A /* UInt32+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8289F3C94B21C93376E2FB4DE31BFF /* UInt32+Extension.swift */; };
-		2C50168E22ACB7A7D9E7ED2A643A1681 /* String+FoundationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E225FF94575A6EAD117CBAF7BDCE9804 /* String+FoundationExtension.swift */; };
-		2C7AA6751A2BF7F5C65E7EDEFA595863 /* BIP32Keystore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E92704F9468A8DC78B75C3F8C46F61F /* BIP32Keystore.swift */; };
-		2CA9E21123C847948518E282093C61C9 /* RIPEMD160+StackOveflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE93D1B7D324256F9D4C18FECD6123C5 /* RIPEMD160+StackOveflow.swift */; };
-		2DBE17D3917228ABDD4392497CD81BF8 /* Promise+Web3+Eth+GetGasPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B92DF881BDEE17A066C7CEB0832AF4 /* Promise+Web3+Eth+GetGasPrice.swift */; };
-		2F3B479B4A026F3280BF4FA333726A86 /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732314F22D2BE49B430C8F340F5E8B86 /* AEADChaCha20Poly1305.swift */; };
-		2FA185075E31AA6157B1CD9E388B33FF /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F4E9080671022998131E7FE850380D /* Guarantee.swift */; };
-		307CB0FCD98B435E4EF121EC3A15138C /* BloomFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAAFE7F970149EEB716AF8A63B196BE /* BloomFilter.swift */; };
-		31909E4DB572212059BC99B11853137C /* scalar_low_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AC98C526C6420EA0CA8A80773A9D5CD /* scalar_low_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		31ADAD2ED18511966F4E763ECCE3118B /* Web3+Contract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F96370375D8B9AD1B4754DC3CE3C556 /* Web3+Contract.swift */; };
-		32466A7539462463993E957EE2462F58 /* Blowfish+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608A1FDD759AE0938FDE3DC293A06A34 /* Blowfish+Foundation.swift */; };
-		32BEA4678DE3E5B0462ECE11BECFC674 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2F80B6633B1B0FC06182C5EEBFF4CC /* Box.swift */; };
-		338AED3F46DE8A9A6C2C2C57D9ED8ACE /* UIView+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627075D1CD3CC2CD9BAC5F5A59164588 /* UIView+Promise.swift */; };
-		3492ED003DC8973858B66BF7D35BFABC /* BIP32KeystoreJSONStructure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E716973755B2E89ADF5EFA78F9A5FB /* BIP32KeystoreJSONStructure.swift */; };
-		34B17DF22062E35B740FA4AA29300ED0 /* Division.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72BC742DB402AF7B08A06EE403E81E34 /* Division.swift */; };
-		35B80D34CC0EA7C97ECC6B78EFCBDEA3 /* group_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DE789C6A63202C00A540AAFF2167D75 /* group_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		373BCBD3BAFD4EEF405BA6A4B1DD206B /* SipHash-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 14075CA0EEA75B672FB159A8787701FB /* SipHash-dummy.m */; };
-		3829A3D356E78A16CFC681BFC31988EC /* num_gmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 37AD0340E0924A6901378EBD6C1DA73F /* num_gmp.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		3944B8F5749A1FE5EBC6D68B6EAA5636 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25B56E6AB08ACA0EE1CC7ABCA0292C7 /* race.swift */; };
-		3A29B014EA2BF3DBF9EEDEB0870AE370 /* ABIv2Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1C9082978CBBE222D623A50BA9029B /* ABIv2Encoding.swift */; };
-		3A7AA8839AB9D27A1E568B8B50851F01 /* PMKUIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = D6C1DEAB322EB0D48D628D067BA01A90 /* PMKUIKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3B1551C7299DACE1B265C05440D44E6D /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B160E67829EADD2CCD679C0D5CD6E82 /* main_impl.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		3C14A6EDB43BEE051ED4B406A33DC65F /* UInt8+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638651C3710123A24F0E3D5389F38244 /* UInt8+Extension.swift */; };
-		3CEA14322993381ACA64215A5DDB6105 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D870040E819D9A05E8263137AED51C2 /* Array+Extension.swift */; };
-		3E080572BF08164EC9E2E1BAD5F6C299 /* BIP39+WordLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58152D6BC0953D378603360B64894468 /* BIP39+WordLists.swift */; };
-		3E3188EE35DEDBA8EAF6854B9224011E /* Utils+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168447759BCDE275D179C1B1B07182E5 /* Utils+Foundation.swift */; };
-		3EDCE35B5BD08FB4348435D94A458376 /* PBKDF2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112A6FCDB04E7C609AE8977DC87F23E4 /* PBKDF2.swift */; };
-		402F05E6635CCF2D45BC09F485F9FCAF /* scalar_low.h in Headers */ = {isa = PBXBuildFile; fileRef = 49891B8F292E9704D7BDC4E521EB5B88 /* scalar_low.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		408B29D76F70B7F2EDF4CD122343EF2F /* QRCodeReaderViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD2BAFEA6D37F1FA154D73188D93633 /* QRCodeReaderViewContainer.swift */; };
-		4108BF7FD69977C4053C02D81AC9B194 /* scratch_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A8D61BB30BC74B566E0E813078D6D43 /* scratch_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		41FA65AF886C76B05AA97BC919A53C46 /* NameHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7CCA70CB80C09C9A5A309B5A9C697E /* NameHash.swift */; };
-		422EFA06EB78BB58512A7A991A381D70 /* AbstractKeystore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE2F408B4FF2738A9F42B10ABC90748 /* AbstractKeystore.swift */; };
-		4261BDB05BD2252A1D37EF501EE7AE26 /* MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946A2B9F0FFB6DC6145CD5838ED9DF46 /* MD5.swift */; };
-		43A213F845B41C54A0C6E74E216D28E5 /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF49644077A1B25CAA8CF54D4DBC095D /* Random.swift */; };
-		43D4B2F276FEFEC71562763C71EC4B0B /* lax_der_parsing.c in Sources */ = {isa = PBXBuildFile; fileRef = DA3B8C705156CC5A9B627D04D4B8CE8A /* lax_der_parsing.c */; };
-		44D5771020DDC133BA8AE2E560771DB9 /* web3swift-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = CA32154A733AA095D64909273E33AF19 /* web3swift-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		456B887CE57F5234CE8302917DC1E4C7 /* UIViewController+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = EC30CA471E3875FDC01611FACEBDEC26 /* UIViewController+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		469AAF3F2BCF89EB1AE5208BDDCD8524 /* BlockEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493CB8292859030078340B11BFF6B29F /* BlockEncryptor.swift */; };
-		46AECBEE3C65BE052E92271C361181D3 /* ecdsa.h in Headers */ = {isa = PBXBuildFile; fileRef = F41A3CD9569B48AC734B519796E3C826 /* ecdsa.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		474541CC65BD4B1D9D073E3D50F180BD /* PlainKeystore+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F42182F81F1407C3DC7D5771E3459A /* PlainKeystore+ObjC.swift */; };
-		479F92D977946F9AD0E3021E34880602 /* scrypt-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7523489901E7C1E4B20D907A43196A /* scrypt-dummy.m */; };
-		4858803CFB9E79B9F1CA5DB45E9BFD62 /* NSNotificationCenter+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A669D344EFFFA9B94F1EA8373BFFC0E /* NSNotificationCenter+Promise.swift */; };
-		4868FC86913C7BEEF591B59A65E1C654 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6DE265854D1861093D783AC9356B49 /* String+Extension.swift */; };
-		48A6422D0964B4423600F7087EB579E8 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0620E42997A0C97E03AAE8CC8BCFBD /* firstly.swift */; };
-		48D8B679DA0511AB8EAC728612007462 /* OFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = F570D9AA2AB57C2A5EBF29E6082D9732 /* OFB.swift */; };
-		4A68E568539B9E22576A80460A0568AF /* NoError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE57327670FC8906B9D407E2D978DD5 /* NoError.swift */; };
-		4A733BAC015ACB5056CB0D8CBD7F69B1 /* ABIv2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD7D8C6393417BDBE5CF9362727B144 /* ABIv2.swift */; };
-		4BD57F8AF66C371F889AB05F16C1CE8C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
-		4EDA34CBFEEAE6A37C2222C46EE940BF /* hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A06551A72C20599D9C7A45956FDBD26 /* hash.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		4F3F51153F6029695BE6BE54FFBDC616 /* Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA59745B42B4791921F39555C5670F4 /* Cryptors.swift */; };
-		4F6D1DF6893D882990C7029249F8AFBF /* Web3+Infura.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BAFC302544761C154C3C312785A956 /* Web3+Infura.swift */; };
-		4F8AA9FE9F4E3062335529D7D616A408 /* libsecp256k1-config.h in Headers */ = {isa = PBXBuildFile; fileRef = EB94837CEC92402155A27E8CB6AAC010 /* libsecp256k1-config.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		507737A3C7801DCFD0BF0574954ACB67 /* group.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CEDBC5518CC046F3FAF974A34A632F6 /* group.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		50BB41FBE680000496F3A72BEC0F144E /* Promise+Web3+Eth+Call.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ECEE2138B5CD007ED894A9B2302992 /* Promise+Web3+Eth+Call.swift */; };
-		50D441DA78ACDC136B35A4ADA9987B77 /* PlainKeystore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B393D0AD2B154707B21DD9E0151F093 /* PlainKeystore.swift */; };
-		5356F05030669B23BAE51298F9EE5403 /* CMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380037FD51C7F639654C9836CAE2E5F3 /* CMAC.swift */; };
-		535A046EF29014CED01BF31BBCC547AA /* Rabbit+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE7DAE7FE8050EFB9EAEA05710A4984 /* Rabbit+Foundation.swift */; };
-		541EE41CC83131708FC4873E24EB6813 /* Subtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F77F20EAEAABCAC2FA77A90BC1F5DF6 /* Subtraction.swift */; };
-		552B747D85A3E5CEFF08F76D9A7474AC /* Web3+ERC20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF492F3A7A03C60C5BF133362B1AF65 /* Web3+ERC20.swift */; };
-		56C1BDEC993C1EB8D74B7D0D83D0A0D5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
-		56C1BF6238EB4EE0364750506A13B1C6 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71B75973741B8C0A92BDD1A39BF6176B /* Error.swift */; };
-		582127B8950A73384E0D7C919A6B9D76 /* Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13A6F0B7FD06E7185579216C8C9F45 /* Poly1305.swift */; };
-		58C54CE909D3981244E323D3DB2EADFD /* AES.Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1816075B02B575B1BE7B00CDBF253774 /* AES.Cryptors.swift */; };
-		5942E74FF6759CDFBB626CD3367F1B60 /* LibSecp256k1Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAB871FAB1037C110E267D4796ECF8B /* LibSecp256k1Extension.swift */; };
-		5B9C17D9478EB66CF57A57017A230058 /* CryptoSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FD4D52CF24250A1E2C8CDC4EAC746E4 /* CryptoSwift-dummy.m */; };
-		5BF4532CF26024B4289655217432FB72 /* Salsa.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423D77A5F4F4FFA5C61FD1B9BC580B44 /* Salsa.swift */; };
-		5C4480ABDB905606FE04DE6062A912AF /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968A1F9CB0E9C9ABD4D80279F7EA55AD /* Promise.swift */; };
-		5D8B08FF6F53F23FF23A5F2C4D5249A8 /* PCBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C1173CE60CDE5D71AF73564BBEF041 /* PCBC.swift */; };
-		5E605FE6C0DD25A97BB34364CC609416 /* field_10x26.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AC375F014CAD55484ACDE4DD147AFAC /* field_10x26.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5ED753E367A75BE0055D8AADD86B71CB /* Words and Bits.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38CE9424BB10682C68AC1F0EAE2F0DA /* Words and Bits.swift */; };
-		5F974AECB341D9D3803F41DBDA5C0C9C /* IBAN.swift in Sources */ = {isa = PBXBuildFile; fileRef = C948126C72F61B79C50B629A1C0D183E /* IBAN.swift */; };
-		60D03407C65DD41B77633BEBA45350BD /* Square Root.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E2F4ABFD2C598332B26D0985CCDF9A /* Square Root.swift */; };
-		60F020078907CC571799F8EEE8657FD0 /* SipHash-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B6EF439601A747708F6DD2FF6242F2 /* SipHash-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		61A35075CF29BE7234EB91A1F892806B /* Promise+Web3+Eth+SendRawTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BD528A7DD471FEC544268CD2A7178C /* Promise+Web3+Eth+SendRawTransaction.swift */; };
-		61C9A5A0D07A83163E761331C3A09235 /* BIP39.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA660D6BB71673919923BCD02318CA81 /* BIP39.swift */; };
-		631BFF10DF9676CB1DE10D503E054BDE /* KeystoreManager+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADE7592EE42D062BA4138EA1897A189 /* KeystoreManager+ObjC.swift */; };
-		6451556051C597D0608E90DD9768DF00 /* HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CD9A900727202456B18505B6F9D3AA /* HKDF.swift */; };
-		64E3A4C3300E39EA19A090640D6E826D /* ToggleTorchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51DD83364DA2F39BA950E45A16A9374 /* ToggleTorchButton.swift */; };
-		6530675BA2CE2AF68B6ABC63A2AC2A48 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FBA9F9CF2F485F33DCE5586671C9E7 /* Deprecations.swift */; };
-		6571B3D9C8C50DAA1B1D90169F930B6E /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7065A796E6B04F32F1944EA52ED3F03 /* CoreImage.framework */; };
-		65CD80DDC802FC77BDD68D3E2AA32F8F /* Rabbit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B4BB25775036EC78B3BF4A5BE8FE39 /* Rabbit.swift */; };
-		667314B78F8C2F2303C1DB976BD6DAFF /* ContractProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CB1D681610799419772BC3B32139EC /* ContractProtocol.swift */; };
-		679171569947CA69B28369CBB64062BE /* Blowfish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CAA5E70273C0F733622CF994C04E8D9 /* Blowfish.swift */; };
-		681D98F4D692FA39C87A2949DFE51F16 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BD253F42CDC5D32643550402722E85 /* Digest.swift */; };
-		6827F78241E84E17AA16A7D10C477746 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F845E5734F0004AFE3813BA2D1956C /* HMAC.swift */; };
-		6890BC23C948237266F16D15073C5B26 /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E15938B0E01C7540EED1359881D8F0D /* SHA1.swift */; };
-		68D37923D30539349D08F686E2060117 /* SecureBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA0C1C52EAA18703E1E942509B0F8E9 /* SecureBytes.swift */; };
-		69E6BE13070187CED87503CD613CAEE1 /* Integer Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FE37645FB80882CAF3C4AB67585742 /* Integer Conversion.swift */; };
-		6A1F54D649142296CAAD7C90C9B613F9 /* Web3+HttpProvider+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB3CE396AC863066AAF026DEB3D6551 /* Web3+HttpProvider+ObjC.swift */; };
-		6B4B70B7430A196D71A62DCB5EFBB3D2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
-		6B76D26A1BDE69761A89455E66A55A06 /* AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 42BE142C960BFDE5BCC533A324E49F38 /* AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6B9A7F86588E7293BD3C8C6E37D6F386 /* Promise+Web3+Eth+GetTransactionDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A02D0753403DB9CE76099B0776D3DC2 /* Promise+Web3+Eth+GetTransactionDetails.swift */; };
-		6E8E66A9BC231CF690F365009629DE22 /* ecmult_gen_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F1A12C496C6650091C82474F2B7E3E9 /* ecmult_gen_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		71B9B8543875E4E32E42B4A9A1312C01 /* BigInt-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 7480746568231EDF17603715FE554263 /* BigInt-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		720E059B6C1676C1BD20419F113E3E08 /* NSTask+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 06689683269F5BCAE45322E0E2E5B38C /* NSTask+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		72DEE3AC5B9A27020EFE91619AFBAF82 /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBA16F895F2F9128478336664AD83DB /* Cryptor.swift */; };
-		74A4839D42C76D84E323A282E4B87B4B /* ecdsa_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 22A56A814792F2D067883D1148C235CE /* ecdsa_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		753B0D2648744254767333E94491CAF9 /* secp256k1.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D98A342E3C4CE42E7EF1BF9FB8C2E41 /* secp256k1.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		759FB72F29405B421C53962F0F326098 /* join.m in Sources */ = {isa = PBXBuildFile; fileRef = 3203CE8CEACEE908C8FCE44171BF2FE3 /* join.m */; };
-		760C04433110DCB2713D0CB160550719 /* field_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 824FFA281F8D34B24AFC5F28C8BCB67E /* field_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		76A07471B25153C90BBE8C37CC9250B4 /* ChaCha20+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F731FE642E29D942A2602E615A503A8D /* ChaCha20+Foundation.swift */; };
-		77E8B7DDA613FB5C879784E0772FC013 /* BlockCipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5D58CDD8D4E7674C84DF5A317C398D /* BlockCipher.swift */; };
-		78384A7DC28D6977EA0C8357325103A1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
-		78BD1B147DE9F65108D04D27A543A1C5 /* field_5x52.h in Headers */ = {isa = PBXBuildFile; fileRef = 52AAE0A2C0DDE48ACF55A256D9FF27DA /* field_5x52.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		78D128DBFC13C4593D650DA41F7E1123 /* scalar_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6545781899C7A95A8BD49CD63992D424 /* scalar_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		78F2BC147CC813133D6356C9BE1ADCE1 /* AEAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423DE1FB7639986D2A99739DD9F77803 /* AEAD.swift */; };
-		7CCB9C64A6DA4EDEF9D02F46E4FB1F8C /* NSURLSession+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 604E46FD931FB989638FAD6E513EE901 /* NSURLSession+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7E3BAFF52BF90BE22DE8B7A31CB5BB53 /* Web3+Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5132DAC664B220CCE54C66915EA32C /* Web3+Options.swift */; };
-		7FBBE87CC46C371F2BE114C62A365F11 /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DDB6D2B5E479727139DEE5E29C989 /* after.m */; };
-		80AF40E9EB7BAABF622776E7EE2FD256 /* UIViewController+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = DFF18856CBCE4C2A15E7E8D5634BE7EF /* UIViewController+AnyPromise.m */; };
-		80B0B462C09D541D9E850D874D656673 /* CFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6324C43D4F9B2EC0C44B602C73FA7999 /* CFB.swift */; };
-		80C3394FE2538008263FA78F9E288416 /* ecmult_gen.h in Headers */ = {isa = PBXBuildFile; fileRef = 364EC788A63B85F05F96A9AACE2297AE /* ecmult_gen.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		81A3C609852663C235928B34CAB031CE /* PromiseKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 75E649687609BA0B77003F631ACCAF69 /* PromiseKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81C1FB472DAAF55ED66443EE6FF59E1C /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE72EDE01F89A09C540AE649E97C3C9 /* Updatable.swift */; };
-		8293BCC7B22412260873FB9EFD99FB53 /* PBKDF1.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1785C3404F91CD2610553CAD01F14B0 /* PBKDF1.swift */; };
-		8398BCDCAC56F650C191A1E73A124B46 /* EthereumAddress+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45F460F0DE60D0DEC59CFA40E7BB519 /* EthereumAddress+ObjC.swift */; };
-		83A1C6B7C6C91FF8750AE385830E8208 /* Promise+Web3+Intermediate+Send.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B603A3DF5A832302D45AA5314EE8179 /* Promise+Web3+Intermediate+Send.swift */; };
-		847A155084AF3DCB445E53A1A33F2354 /* RandomBytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D01587ACD40F5E9332D90792B4B2A6 /* RandomBytesSequence.swift */; };
-		86B72C362BAA2E77E8DB73120A057020 /* PromiseKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 741946BB436E10C32D32D95AA6E2C46E /* PromiseKit-dummy.m */; };
-		8956888E1CC6894013EBC449101A3EBB /* UInt128.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5552C4D8C9464EDF1E94F0B4FA62ECA5 /* UInt128.swift */; };
-		896297A6EC22A9600BD62BF36360D60C /* eckey_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D8675FDA4BA5887BCD243BBD6DFAA05 /* eckey_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8A597DC225922DDE99468A6D330E41B2 /* QRCodeReaderViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA62EB56D9502B656E1ED4F5FA1309E /* QRCodeReaderViewControllerDelegate.swift */; };
-		8AD769BC9791E6C53FF3CD35554AA1D5 /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD25864EC42F1D4A3ABE45779307FB0 /* PKCS7.swift */; };
-		8B0AF3D31FD7DE15D88A8BE59CC2FC85 /* Web3+JSONRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0564D106B866DFD63A27D0AE1AC7AA21 /* Web3+JSONRPC.swift */; };
-		8B1FE06FFB95E1BE525603F1D9955034 /* Web3+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00EF881409ABAAA333E7D4C52F6FA0B /* Web3+Utils.swift */; };
-		8D4878D23CC348B8C4302BE447DA9F8A /* lax_der_parsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 6550B0F982A3AFAE39A3901DF284CFE4 /* lax_der_parsing.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8E1E2E8AF7F530A2BD21A0F324B0CE6F /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60752C72B20ED22FD8D88C7502A2EDEF /* AVFoundation.framework */; };
-		8E5F935FFC0DDAAF57F9B7642740BF8B /* KeystoreV3JSONStructure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E8AB5ED7BFCC8954C8B2DD7245033D /* KeystoreV3JSONStructure.swift */; };
-		8F016113B2425520977300A66BD4B319 /* BlockExplorer+GetTransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52974B5C907F23B4873E61DEBD141134 /* BlockExplorer+GetTransactionHistory.swift */; };
-		8F25704823E74D4F7324445281286FE0 /* NSURLSession+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27337216DDF15B18B0DB1B9B6F8B735C /* NSURLSession+Promise.swift */; };
-		8FC26FC4527AC222B1C2F40D4E1F3D81 /* Primitive Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F57ECA9E5BBCCC7BCCCEBC506FE75A8 /* Primitive Types.swift */; };
-		910DECB543C55FB96E09E4E2557A6755 /* Exponentiation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0E4445536E7E006B2D0CBE3BA980AF /* Exponentiation.swift */; };
-		91DD917708287C75B4AB4B8352BB833B /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CA91F2BD5FA1BFA7F689AD425A3FABF /* PromiseKit.framework */; };
-		9345F9F5DAF71289D5E677F5726BBB60 /* Web3+Eth.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2BE125C18E4B43224734B6002B0467 /* Web3+Eth.swift */; };
-		93518324F84C9EDB96CC06AB53DB330C /* Promise+Web3+Eth+GetBlockByHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC93974BF783269BAC12B91F8592233D /* Promise+Web3+Eth+GetBlockByHash.swift */; };
-		936376510B6C0560978BE9B6F9D4D5EF /* Promise+HttpProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0822E6C8EC34132E8689B41A4A9A42 /* Promise+HttpProvider.swift */; };
-		93EC97477C57529354AF8E85681D30BF /* Promise+Web3+Personal+UnlockAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D5BB8EAB2F4FB5B4DCEAF94C6EB713 /* Promise+Web3+Personal+UnlockAccount.swift */; };
-		93ECC8F5ECD659159576FCD7EC62A9BD /* scalar.h in Headers */ = {isa = PBXBuildFile; fileRef = C43A02AA2A26B7A19A6767BC973BAD85 /* scalar.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		94C78D2A4E635D01A9CD9986AC8CDD37 /* UInt64+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B114219677B4C10C3E66F96A5BC6DD81 /* UInt64+Extension.swift */; };
-		95A614F4944FCBD7134BB7C405CDA69C /* ABIv2Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22281779014B1860B15BD0DFAFE85BFC /* ABIv2Elements.swift */; };
-		97CC2191FF1F5BF6E007E1F0452D3835 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC6410BC3F9BBCCD4AE87C8A69D8A6 /* Operators.swift */; };
-		98C459EAEF81D101622627E37AAD0946 /* AES+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45CEDB397684979E7A94F5717A7DFB8 /* AES+Foundation.swift */; };
-		9939A142556FE3DE5C19FF9BDAABFCA7 /* UIView+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = BA78A7BEFA2005B4F4984EB44F936189 /* UIView+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		997F1730D7482B9BB12D1B62E227F555 /* EIP67Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7183803460616976586A715AFC5D10E /* EIP67Code.swift */; };
-		9A683FAB2843A7181358FFC2F9AA7FAA /* BigInt-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 116491EB3DDBCFC5D26AB838F91A61C4 /* BigInt-dummy.m */; };
-		9AE3952131E530F55D34A350ECC9B909 /* Multiplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8353E7ABE22A3D8C80B5560B6C664C65 /* Multiplication.swift */; };
-		9C21F8BD616A0A6F9B42A9A9C4B2C0BC /* Web3+HttpProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB48D68DCB17B1C07B05A6D6B3EDC766 /* Web3+HttpProvider.swift */; };
-		9CF67C923B79810A9C5DDD8C4949E9D0 /* Promise+Web3+Eth+SendTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C646FB1DA299FF412F9BDC68F40E0E75 /* Promise+Web3+Eth+SendTransaction.swift */; };
-		9DA1244904AD9E535DFE95EC136A5799 /* Floating Point Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D2B4F401F83AED97758430F7961B31 /* Floating Point Conversion.swift */; };
-		9DABC6A806D00241695EE106356E0724 /* ABIv2Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD9140A70E4F1E11E22F06BF0413344 /* ABIv2Parsing.swift */; };
-		9E93BE33E88E3B32CAFCCC9737459B5F /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30F1C78CB74595997600FCDFFECFD859 /* CryptoSwift.framework */; };
-		9F1FD140D7B763EFE5906D0006DC6DE9 /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 86A8C87298BB26C969E9D9D731E59D54 /* main_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		A028F5CBAFFEDF5AF188D077ACF062B7 /* hash_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = E92AE203A4F44CDC83748EE2EFD101CF /* hash_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		A1B6A33DDDF1D1B9148786E477B24720 /* ENS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0F9A14D8E737876058FD244DCF8451 /* ENS.swift */; };
-		A1CC8159BD821983537482D11A59411B /* hang.m in Sources */ = {isa = PBXBuildFile; fileRef = 53C2D41F3888015B5D33A898FD0BDBA2 /* hang.m */; };
-		A1F0EC742D51427285C0F99AE1D57B79 /* Web3+Instance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A760383154BE7CDD10490704A13AF43E /* Web3+Instance.swift */; };
-		A2D9742D1A9BF2A257A9B380EDD3FA9A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
-		A31AB7272EBF96F61B8FD0F77AD3EB7E /* web3swift.h in Headers */ = {isa = PBXBuildFile; fileRef = BF8B7DC811049895554DA6E7651A5692 /* web3swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A33B905167DA52EF4F9447A372789E87 /* secp256k1_ecdh.h in Headers */ = {isa = PBXBuildFile; fileRef = 601B089A77FC1BDA7B65D8B49C417791 /* secp256k1_ecdh.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A425AB2AFD2A6AC8C9AD47D474E8F964 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B00CFBE0F680096E1581F6B59A0F5F /* CompactMap.swift */; };
-		A474A2F36899E23BEF7E72CA542AE16B /* scrypt.h in Headers */ = {isa = PBXBuildFile; fileRef = B6761F1748940B1DDC2C2B4EC1A2A625 /* scrypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A551E86CC0AF1D873DA6C4A0A44CC9DB /* Promise+Web3+Contract+GetIndexedEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C058AEDF0EDDEDF0E6CD7FFD7ACD7DBC /* Promise+Web3+Contract+GetIndexedEvents.swift */; };
-		A5B2AC85E75DBD4083EA59AC1B4DF221 /* Base58.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C890F5D6BDE1F66CCC42BCA89FC70C9 /* Base58.swift */; };
+		00E450DAE78DD6DC993B5DAF0DAE3E80 /* field_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = A0A296B44654179E862676929D0D08A4 /* field_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		01ADF8FEF4DF28905B2F70A9FBE5D1B7 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329D2572A9B9E9AB32813C05710EFB65 /* Configuration.swift */; };
+		01F1BB5AE9C9FD00910D95054BA3AE1B /* BufferStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB070DE5C274B1063284536E06DF63A /* BufferStorage.swift */; };
+		023904EB2AD527013067710B19463BD5 /* AnyPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123708BCF6EF6B6B3CBE29C625D073FE /* AnyPromise.swift */; };
+		02E8046C2A767EA8848448EAB9E07A65 /* DigestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20376F2F2EEE94392F56BFCD0AAA921C /* DigestType.swift */; };
+		03FA8EDEAAF28C2F20B6134374C42DAB /* SipHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754C8F70937EC24C697F6128DEA15C39 /* SipHashable.swift */; };
+		047A0D63C193F5121712C49A69566C71 /* Promise+Web3+Eth+GetTransactionReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBD96EC145E10468934052206A64E8 /* Promise+Web3+Eth+GetTransactionReceipt.swift */; };
+		051E0DE7AC9BBE760F701E5472D220D3 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC88FC19324B1F65425A48229FA2A9 /* Deprecations.swift */; };
+		05A846483F7B82BCDD0A009DF3B2F72D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
+		062CF63F7C8BA7187034E313A85F18AE /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EFCF9E0550A93DEB58F8D4FF35A5A2 /* Thenable.swift */; };
+		063172677A7320FA0176B8142D11805E /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C7E60C088422063704BC0D090F67C9 /* Authenticator.swift */; };
+		0717ACAE7ECC2E7D2E33FEEB38A76E2F /* SHA3.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A17E180C775F133971F5BEA1EC703F /* SHA3.swift */; };
+		0732B277DE0821A2E9F30FD82A2D505C /* SHA2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471B3967D8491DAB0642DC353C096A6D /* SHA2.swift */; };
+		07A516E5DC61219A239FE2E3E902E691 /* ECB.swift in Sources */ = {isa = PBXBuildFile; fileRef = D79791C3084EDB6DCB40FDB9CC457AC1 /* ECB.swift */; };
+		07AD36BB4CEFE9208E337716C4B0A860 /* QRCodeReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6AE0B6578FC38928FDAE2A1D7F1950 /* QRCodeReader.swift */; };
+		08020B2FAF536D0A83DBB3A2C1D933B9 /* group_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AC84DAA646EBB604B4ED6B56F4D44F7 /* group_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		08166CF14CD2924DA16C386BAB8C3867 /* Promise+Web3+Eth+GetGasPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC0D7B391633DBB114E1F27A93BA165 /* Promise+Web3+Eth+GetGasPrice.swift */; };
+		086443BE824CBF220F1E1493106DBFB2 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30F1C78CB74595997600FCDFFECFD859 /* CryptoSwift.framework */; };
+		088387733523D1CAFA7D4DC267EA4433 /* Strideable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBB1FE361AE2CCD511B0C4C5EB4F94C /* Strideable.swift */; };
+		09648EACD312EC7080BB4E2CD9B0943F /* CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400974DD0BAFA502C534CED0FDF36E4F /* CBC.swift */; };
+		0A0702807C69D2A69C9033A16D16E97B /* scalar_low_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = C1115E6596EF196DD2291F81C4C9C181 /* scalar_low_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0EDF28FB31610CF486B81E0FECF1267F /* secp256k1_ecdh.h in Headers */ = {isa = PBXBuildFile; fileRef = 04AE81D5DB9F4D8240587148767BDFF6 /* secp256k1_ecdh.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0FA7E1ED09D6CB457D8B1F5880A97CEB /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15A11FE00702C88874F947C5C5D37DA /* Data+Extension.swift */; };
+		101CEC15F6F283289721E6DA1640B5DB /* AES.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE1AD5054A208E4D3DB80B6C9F6916F /* AES.swift */; };
+		10A58D14F48DC82BE0A74505ACD12284 /* field_5x52.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B0C4497D7B3C9C961FCE0CFEE1099B8 /* field_5x52.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		11155D066240AA9BCB5FB19A8915C253 /* GCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = A380ABE0FF9C088B8F0379EECF25B523 /* GCD.swift */; };
+		14D78EDD36995D76475898CE85832A2C /* scratch_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = DD812908B6A8A5739F6E827AD436419B /* scratch_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		14F3A21C8F4DEFBE0C594B26EF4FFDA4 /* NameHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A7144477B01A7D9D160DFD8C0A8C42 /* NameHash.swift */; };
+		15302D6A0DBD3F5FC3056011D7BD8AC2 /* ecmult_gen.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B3FA166F72D9546A2CBA57933AD2886 /* ecmult_gen.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		15A90544B35843906C8B140ADBB41BD3 /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BFC8E2A0E61395AB165CA6C1500F71 /* main_impl.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		165E24DD114893AB8FFB401FF99359E2 /* fwd.h in Headers */ = {isa = PBXBuildFile; fileRef = 0541307DD5375D347F8E968760A8B67E /* fwd.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1704C51E944C91C566E9ADE2AE5523B4 /* NSNotificationCenter+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = E59CC11F6ABC89EB9FA27553CAACD3C8 /* NSNotificationCenter+AnyPromise.m */; };
+		1705B469D469EC1581B939E2626A18DA /* EthereumAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D040FBD626100B2AD97DA4094AC0FBD /* EthereumAddress.swift */; };
+		17131138F56BC6E14EC1CDD34235C9FD /* EthereumTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204B9F811E9F85B65EACB4BCE2A0E40 /* EthereumTransaction.swift */; };
+		1850A3735865F68F0474EA40F62EE21D /* RIPEMD160+StackOveflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E59CA843B29EDC922D24FCE451B57 /* RIPEMD160+StackOveflow.swift */; };
+		189B682B8F3FCC98CDF5C9323ACD56B8 /* Web3+HttpProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F4C8B0EAA83CF8E5F07AFBF5FD6281 /* Web3+HttpProvider.swift */; };
+		18FA405787153F24474D350A8F06B31A /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60752C72B20ED22FD8D88C7502A2EDEF /* AVFoundation.framework */; };
+		19205E9932BE7576D08EA1325104EAAD /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30F1C78CB74595997600FCDFFECFD859 /* CryptoSwift.framework */; };
+		1C53AF4113DA6608A4B207AFF139039A /* RandomUInt64.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CE64D280A804FDEC24FC205D78FED /* RandomUInt64.swift */; };
+		1C6305612C71BA4A41EA3EE86EF9DE98 /* Addition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D89FB56598E9FDF2253200788961542 /* Addition.swift */; };
+		1EB5C7E4EDF2B79FBAE67F37FCB6BDD3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
+		1F4BDDA00F127CA95F0BFC9F034BD28D /* ChaCha20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466E434A39BBD238A4D05E63F2A34E4E /* ChaCha20.swift */; };
+		1F522B047157244684FC7A469A5654D5 /* BlockMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB95A76496EDC5724E41797B5EE2F51 /* BlockMode.swift */; };
+		1FC3FD39157C2FFFF3869A1300730086 /* SessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C843EBE82ACC990822A3F32C0639EBC /* SessionDelegate.swift */; };
+		200B9B56FBA48FE6906A130C24431419 /* PlainKeystore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD052C962A755E481A48E56C9C09C6D /* PlainKeystore.swift */; };
+		2058A726DD078C04D63E243565CD07E1 /* BatchedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC95AC35C6E78B9879CAFF04EEB9578 /* BatchedCollection.swift */; };
+		22534153749FF789988A709D3940AD70 /* ResultProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DBBC54280BEBF480E364971D5239C7 /* ResultProtocol.swift */; };
+		22FBB963C8F71C0D438D9284D74003AE /* Salsa.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AF4BA027E7452FA710EAC1913382A1 /* Salsa.swift */; };
+		22FE67B665841A937E8D95D9DBCC7EB7 /* Bitwise Ops.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4760D4934E5BC86AFC5A4E4A63E99D4 /* Bitwise Ops.swift */; };
+		23E69E19A1E45A210A051F28FBDF4279 /* Checksum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE7DE1D82E20261BF472C2DA17A014A /* Checksum.swift */; };
+		2527808B40692A8D1F95E47478560B99 /* Web3+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314780CA47604CA2ED4B735A4A3EBEBB /* Web3+Utils.swift */; };
+		252B1CFFD30EEEA350E6AD243D63414D /* QRCodeReaderViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4996D8E35AB40C6394A8C8149844B437 /* QRCodeReaderViewControllerDelegate.swift */; };
+		25C5482FFA8F4EA9C80233389DBDDD85 /* BIP32Keystore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27015053B3711311638314C3A7F0E3A3 /* BIP32Keystore.swift */; };
+		2692BCC812006C65B73E2F05579F3EB9 /* NSTask+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = D9809E72EB7D02EF0C1B11F3C209AD5F /* NSTask+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27435128253747301FD929F5DBDCA4B5 /* Pods-DiveLane-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 52EA56A9EF83E4CC6F7B02F5D1878DB7 /* Pods-DiveLane-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		288250141FA353726E30472933B3E9DC /* Prime Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49B215782D27272CEBB1CCE548EB490 /* Prime Test.swift */; };
+		28B4E6A51F1638A431729AB5676C39B9 /* basic-config.h in Headers */ = {isa = PBXBuildFile; fileRef = C787950D811A87FB57E6DE5D3B1A8DE5 /* basic-config.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2A0A446FDE9C20B00ABED6AAEF4D66CD /* UIViewPropertyAnimator+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F2B3C6389C3B20BA6089734B930EBE /* UIViewPropertyAnimator+Promise.swift */; };
+		2B1A7912BC4619FA895DA18E9947BB4B /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7065A796E6B04F32F1944EA52ED3F03 /* CoreImage.framework */; };
+		2B1E44CBDD1017D5577B14AE21CD068D /* Promise+Web3+Eth+Call.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5BEB238DEA66EAD3E72BCD58B993D0 /* Promise+Web3+Eth+Call.swift */; };
+		2B207C79219F8FC6771FC8499423F40E /* NSTask+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E62C76699E81E04C05E307B6A8AF068 /* NSTask+AnyPromise.m */; };
+		2B3E5D56DF7BC0A8F5EC634A6F4082BD /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25B12E92E17375D241B10885F86F090 /* when.swift */; };
+		2BCA931010327B7616D84860C4E8DE2A /* UInt32+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614F03A94B3CA7BCFE7AD4B98555030F /* UInt32+Extension.swift */; };
+		2C50168E22ACB7A7D9E7ED2A643A1681 /* String+FoundationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79DB94B5E2289A1FDE5D100D10433F4 /* String+FoundationExtension.swift */; };
+		2E160B7C362227F145384C3C17323918 /* KeystoreV3JSONStructure.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3524EB86E47609DFFFA6E121A73E5CD /* KeystoreV3JSONStructure.swift */; };
+		2E46D003F391554493DDAF4F1152057A /* Promise+Web3+Personal+UnlockAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07523400160228A9177C0F89B5A538FF /* Promise+Web3+Personal+UnlockAccount.swift */; };
+		2F3B479B4A026F3280BF4FA333726A86 /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A3ADDF7A53DF282AE4E6A160C657D2 /* AEADChaCha20Poly1305.swift */; };
+		301EE9FBEE4A993A4C76C137ABD426A3 /* ReaderOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAD748EABB865472012722BBC282CA /* ReaderOverlayView.swift */; };
+		30CB7ADC336A63AEDF18C84C6296DC90 /* ecdsa.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FDDD749C3760952A98C4202E2CD7F99 /* ecdsa.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		310C9BF056AB994B2375B2562996F56D /* Web3+Instance+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D05D2A1BBDC61553D83CB65BD52980 /* Web3+Instance+ObjC.swift */; };
+		32466A7539462463993E957EE2462F58 /* Blowfish+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D841A94F02EE18231C3A6082413C6926 /* Blowfish+Foundation.swift */; };
+		341896E79DAE50466B354002773EBD8F /* UIViewController+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 10A0AD3FD6958085628104AAFCB8C3C1 /* UIViewController+AnyPromise.m */; };
+		34B17DF22062E35B740FA4AA29300ED0 /* Division.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9A2A62C6BE578858DAF7399D3F4241 /* Division.swift */; };
+		352F101124A05162CC7A023592F89976 /* Web3.swift in Sources */ = {isa = PBXBuildFile; fileRef = D343411628B4DF169F56E7AFE870A582 /* Web3.swift */; };
+		369E07C5AB03665A3DD4404972F6CF44 /* ContractABIv2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE4C1AA983DDFB7CFBD319A1A3354F5 /* ContractABIv2.swift */; };
+		36FF8853CB34A9297AFAA8F5F7456324 /* TaskDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC8D1E73F3D420CD00739B71C0703B8 /* TaskDelegate.swift */; };
+		373BCBD3BAFD4EEF405BA6A4B1DD206B /* SipHash-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 68D9FB9D5B9D0CDF0571383B95ABC1E4 /* SipHash-dummy.m */; };
+		38419A5DAF2E880B7883784CFA2FDCE2 /* UIView+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 96D1D17378722BAD8574D405DC1F248B /* UIView+AnyPromise.m */; };
+		39AEF40199252CBF5FC30255F29478CA /* ABIv2TypeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B0D548D90EED6693E65BFE9FB8FB3F /* ABIv2TypeParser.swift */; };
+		39B9B0C7235DC9EE84F094F507C8B224 /* Base58.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED02205DB9E2AA26F8B91AF593BC46D9 /* Base58.swift */; };
+		3C14A6EDB43BEE051ED4B406A33DC65F /* UInt8+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DE5E21F680A68C6578671B653D71B8 /* UInt8+Extension.swift */; };
+		3DD4CBC5260127158BA7EB3298168EA5 /* BIP32KeystoreJSONStructure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200F222DE33017888FF05655EE1C54CC /* BIP32KeystoreJSONStructure.swift */; };
+		3E3188EE35DEDBA8EAF6854B9224011E /* Utils+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202049474E0CCA0236B0BB25EB3F7428 /* Utils+Foundation.swift */; };
+		3EDCE35B5BD08FB4348435D94A458376 /* PBKDF2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD7F26A557D98A7C91689CB5A60D36D /* PBKDF2.swift */; };
+		3F767BF3B4D36825ACC636684D6761F0 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B2ABBEA99EE344B066F54DC7AC1813 /* Promise.swift */; };
+		3F7BFFDD3A8601304CEF6BBF9B124C86 /* Promise+Web3+Eth+GetTransactionDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE1814071187E6505D8CCDF37C0FBD7 /* Promise+Web3+Eth+GetTransactionDetails.swift */; };
+		3FD3AC619466F2C5C030C275E5FBFD1A /* scrypt-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FDAC5548CA3EB33BFEE567F190504B5 /* scrypt-dummy.m */; };
+		4016BD78E12B885C061DC2926E93FE9A /* Promise+Web3+Eth+SendTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C72BB8D51ACBF1419C13135AFA27E2 /* Promise+Web3+Eth+SendTransaction.swift */; };
+		40E1945A90EE5B5A7DC369B078E77E55 /* AnyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5705E17A5DC8CD041A2FCB5A82346147 /* AnyError.swift */; };
+		4131579B2105A058790FFE28D7DDD7BA /* lax_der_privatekey_parsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D1C71B00EC0B4FF2154BA22D57B1B84 /* lax_der_privatekey_parsing.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4173934A29B2F23DD9C85E5D4BF28CF9 /* Result-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 248F8DA7C2CEF6BE3B419CC9FF46EE91 /* Result-dummy.m */; };
+		41D4B2B2836194F9274B2BAAF90A047B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
+		4208A2E92B8AE0BD48D0E2802467D954 /* secp256k1_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA855DC6412290B5286A9DD3D5F8FA5E /* secp256k1_ios.framework */; };
+		424D08F2723FA1787938D86A1BC76120 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
+		4261BDB05BD2252A1D37EF501EE7AE26 /* MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6473E6D83C12C75419CCA654011714F /* MD5.swift */; };
+		42FEEADB098E943F9485E9BB8BC473BC /* Promise+Batching.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81BD1624603AFA149D3E661A842C8CE /* Promise+Batching.swift */; };
+		4302B0FD5B5072F552F53D32D8D41713 /* ABIv2Decoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A8581A98F919BDD990E2151B4CD5DA /* ABIv2Decoding.swift */; };
+		432BB99529E39113DC6EE0432EEC9663 /* Web3+Infura.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3019DE0415EB42DFAFD80C013444D7 /* Web3+Infura.swift */; };
+		43A213F845B41C54A0C6E74E216D28E5 /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5098F30FAB47D07396CBB0BE1DFED618 /* Random.swift */; };
+		452051D6BA537B8695338A85D938E7C1 /* scalar_low.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DA9457B5C2C61A5998AB2070FDE20B0 /* scalar_low.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4526579B0116E5DD2556B4C55FAF4455 /* EthereumFilterEncodingExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A0705AACC34D9047350BA409367FD3 /* EthereumFilterEncodingExtensions.swift */; };
+		469AAF3F2BCF89EB1AE5208BDDCD8524 /* BlockEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1D1283598DD9FB40501814B446C432 /* BlockEncryptor.swift */; };
+		47216914F2A4679832458D0422D90110 /* scratch.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D296AC4874D9018CD682D9BA4930FE8 /* scratch.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		47E2CFA66B02443586299818C8AFB954 /* Web3+JSONRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455F2819B3A0EA97496C5877D0E29378 /* Web3+JSONRPC.swift */; };
+		48596848E4B2BB2477DC73C19FF0F1AC /* ABIv2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E196127E64DF41026ECBAD011870259 /* ABIv2.swift */; };
+		4868FC86913C7BEEF591B59A65E1C654 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7782FBF474D27894445865F06B1F5AC2 /* String+Extension.swift */; };
+		48D8B679DA0511AB8EAC728612007462 /* OFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7BEA031DC24D8856BCB2D0F517DC6E /* OFB.swift */; };
+		4BBEE38121FB5320986BC7890B7157D8 /* PMKFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 937EB2F54E66DF5CEDFB6F004E8F1F2E /* PMKFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C5FCFDE211A11AF01E44A0D1F74645A /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 868CA8B8525183BB82B5B7EC40669EFA /* Box.swift */; };
+		4D5CA24A2F318A927383D4984C766CC6 /* Web3+Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B124045913A60D2E6F4B128D31FB54A1 /* Web3+Wallet.swift */; };
+		4D801F8EC17739B1E30D02078159997C /* AbstractKeystore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4CCC3CD81989D23B696E7053A33F40 /* AbstractKeystore.swift */; };
+		4E1A913EFB404FB11524718FF0298EFE /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE793F8B74E5CCD76899F63529F9CB04 /* Alamofire.swift */; };
+		4ED4F6CF1B8A1EF0499AC7203572BD53 /* Promise+Web3+Eth+GetAccounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD42F09517187F64B86B1D785855A84 /* Promise+Web3+Eth+GetAccounts.swift */; };
+		4F3F51153F6029695BE6BE54FFBDC616 /* Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = E076F4231256E2BD592009B01EAB1489 /* Cryptors.swift */; };
+		500C8EDA60C07B0F127C7FC385E17D38 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939E4127DFDB5C703CBE8DC97714FD01 /* Notifications.swift */; };
+		51AD6B850E8F967A26394BEF6DBCC35C /* Promise+Web3+Contract+GetIndexedEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B393D9B7755F5DE1F1A4B16B75B34E7 /* Promise+Web3+Contract+GetIndexedEvents.swift */; };
+		52237C35642089F77DD4D723CEB25737 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46CC1978DC1AFE01C606CAE78F5EB25 /* Response.swift */; };
+		52C8DB9D1DC75CA87CB1700F1A7FDDA4 /* ecmult_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = FAAD058A045B19FB88C786D6B60224BE /* ecmult_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5356F05030669B23BAE51298F9EE5403 /* CMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A96BA88952EE60DACD64504880387B6 /* CMAC.swift */; };
+		535A046EF29014CED01BF31BBCC547AA /* Rabbit+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF1750F92AA20B76F5A46748B45B385 /* Rabbit+Foundation.swift */; };
+		541EE41CC83131708FC4873E24EB6813 /* Subtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5299483F73A2F9F3D986E18B127574 /* Subtraction.swift */; };
+		54BC8601AC0925470765411361F5C869 /* NSObject+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4C3BB6186F689B7AE840596A84078B /* NSObject+Promise.swift */; };
+		5714E1F957F10FE8D3B68F6E58817ED8 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DA768214F620DEBF8CB0659D04D1A5B /* util.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		582127B8950A73384E0D7C919A6B9D76 /* Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFEF8A63F93FB41D6119F765F6D3B0C /* Poly1305.swift */; };
+		58A9719584AFA2D108D9E5C585A79329 /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD7A4E497D99E6792618A7AC28151C0 /* Validation.swift */; };
+		58C54CE909D3981244E323D3DB2EADFD /* AES.Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3219EF7CD0C2F08F7F966C59EBD7E201 /* AES.Cryptors.swift */; };
+		5919A71B89C3F5AA506DAB7F3D6798BC /* Web3+Contract.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6FA2B4E48BAAF86E40E8B34BCCF974 /* Web3+Contract.swift */; };
+		5B9C17D9478EB66CF57A57017A230058 /* CryptoSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7041BC27C28AD00A274104896D8943E3 /* CryptoSwift-dummy.m */; };
+		5C43F79B94C6F6221B999CBCF5B2BBE2 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF465D10A7EA9D71A99A1C40B58BE3A5 /* Error.swift */; };
+		5C93BF92E1D9CAE2A236D40F10EF5449 /* AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 871136A970C2EE6E1F4E02424D526B91 /* AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5CA1C6A73D09962F6596979CA3ADE64B /* dispatch_promise.m in Sources */ = {isa = PBXBuildFile; fileRef = 35A7901737C34A9742D5B99DC7C9466E /* dispatch_promise.m */; };
+		5CFD2A9370693702B6367CD3E9C8C4F3 /* scrypt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39ED000938F638B38685F1C7D5E22786 /* scrypt.framework */; };
+		5D8B08FF6F53F23FF23A5F2C4D5249A8 /* PCBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6416379E455C5139431635058364658B /* PCBC.swift */; };
+		5E06B41CA2AA7D224F679FCDBC3B65D0 /* KeystoreManager+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41366DDC06EA73CDFBD8E1CA9C774F03 /* KeystoreManager+ObjC.swift */; };
+		5ED753E367A75BE0055D8AADD86B71CB /* Words and Bits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F13C96ED45C95FC41551CDE5A6D68F /* Words and Bits.swift */; };
+		5EE5FED83B90A606A763CF1114D1D6FB /* ResponseSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD6BB50AD8EF2630AC60A823D4D8B38 /* ResponseSerialization.swift */; };
+		5F890D66CAE3B2F537033C8625DB8E19 /* BlockExplorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEB6BCBCF2FA9650F28438EF13B70FA /* BlockExplorer.swift */; };
+		60D03407C65DD41B77633BEBA45350BD /* Square Root.swift in Sources */ = {isa = PBXBuildFile; fileRef = E089341E2F3DB80083CC5A32964F8E67 /* Square Root.swift */; };
+		60F020078907CC571799F8EEE8657FD0 /* SipHash-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 067A6AD52AEA1B0726AFE145CAB24931 /* SipHash-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61075231F0ED9619CB4AC8837C9A09DD /* EIP681.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CEDC0A46453491F47C267BB99CA85A7 /* EIP681.swift */; };
+		61DF824D4F9281580C773CCC6ED413B2 /* BIP39.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C2BB327C9C1AAFC7DE617C91C6D1CDA /* BIP39.swift */; };
+		63A223833D2742F61675DD880B77D824 /* hang.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FF820BE0E9F0B29D4E6A63A9E9CA7A6 /* hang.m */; };
+		6451556051C597D0608E90DD9768DF00 /* HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BE5D5DB99C60B6ECB4AA4CDCECFCC4 /* HKDF.swift */; };
+		655B7373FA724E80DBF802D07B1BD68E /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AA4804DE767546B170499C025D3872 /* Catchable.swift */; };
+		65CD80DDC802FC77BDD68D3E2AA32F8F /* Rabbit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A31C3BD52129B6DFCF9A0C8BCEE1781 /* Rabbit.swift */; };
+		6626CB2A08C917C093B2264498488AB2 /* Web3+HttpProvider+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FF436EC9B609E571B4778D2AF17F45 /* Web3+HttpProvider+ObjC.swift */; };
+		66EACB1311A561A97A89DAC9CD38D293 /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = A231571D3499DDA617E10EEA78857D32 /* CustomStringConvertible.swift */; };
+		67674EE7FC179283E6F0B4C4EDADC479 /* scrypt.h in Headers */ = {isa = PBXBuildFile; fileRef = EA2334F5B6CC246D4C90FF86CF55D594 /* scrypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		679171569947CA69B28369CBB64062BE /* Blowfish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4589A3D54AFD2251264C4910E695872B /* Blowfish.swift */; };
+		67E81553B67058901E26634B52225EF6 /* Web3+Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5ADDF19D753AE50759F2928852E35C /* Web3+Options.swift */; };
+		681D98F4D692FA39C87A2949DFE51F16 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84FAB4B01608C152C252FB69EF57D28 /* Digest.swift */; };
+		6827F78241E84E17AA16A7D10C477746 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D61860F5FD79DD8123BCB7ECA75EB /* HMAC.swift */; };
+		6890BC23C948237266F16D15073C5B26 /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69FE100A8E9CB0B6B86E4A44DFF1824 /* SHA1.swift */; };
+		68D37923D30539349D08F686E2060117 /* SecureBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E47EB0AFC3A421CC5AB0E56AABFBA8 /* SecureBytes.swift */; };
+		68F27886042C31143EB3A22573DBDFB0 /* secp256k1.h in Headers */ = {isa = PBXBuildFile; fileRef = E147C791AC66BEF59781D15B1BBA68F6 /* secp256k1.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		690B4BE64DCC9802E9908E9F3847C929 /* Promise+Web3+Eth+EstimateGas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5F4741DEF41B9DE628EEF93D72CB87 /* Promise+Web3+Eth+EstimateGas.swift */; };
+		6975328EAA470D8B97FD98F661BF3704 /* ContractProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE955DAE69C8E70BC0EFC70000E07FC /* ContractProtocol.swift */; };
+		69E6BE13070187CED87503CD613CAEE1 /* Integer Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96258CEA10BDDD00990C9B904A3AA9D2 /* Integer Conversion.swift */; };
+		6B0F4FAC46A2DBE742EF6D376BD03CAF /* ecmult_const.h in Headers */ = {isa = PBXBuildFile; fileRef = 46FBB4349EC969ED97E0E4CE07FA1333 /* ecmult_const.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6BEA14EC335E07C7063CD1383C0C443C /* ServerTrustPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3507236898BBAB32C5E17C54301D2439 /* ServerTrustPolicy.swift */; };
+		6D513EE6B71A91EA3C364E543C8608BC /* UIView+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 930ABC6D2AB929B6B0B0EF49AB3FF50B /* UIView+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DBF7CE6628CF9699C2C3BE302EED673 /* ecmult_const_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FD8FE5B63CA9FD72BE519AF59F5E1B9 /* ecmult_const_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6E8044AEEFA21B9B4D9718F4ADAA1DA8 /* ABIv2Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477123AC338560B8480BAF4EB5D7988E /* ABIv2Parsing.swift */; };
+		7068E8A7DDC1424EE8F24BC77E8746F4 /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA16A9AE900F8E53C16B7639911CFB8 /* SessionManager.swift */; };
+		7109C06E96166F681B1950B6709F7A24 /* Web3+Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78100FEA5A147FDAC8E526311C18EE60 /* Web3+Protocols.swift */; };
+		717BD63D3A6607AF9DC07F82D6725DFF /* Web3+Structures.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3679BBFDE812DA031A88BA78BA37E13 /* Web3+Structures.swift */; };
+		71B9B8543875E4E32E42B4A9A1312C01 /* BigInt-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4647F04C7ED31642A5C97FFEB14C4FD0 /* BigInt-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		72DEE3AC5B9A27020EFE91619AFBAF82 /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E53A5B5BC58ADF41631607A5FD30732 /* Cryptor.swift */; };
+		739FE69AD413F5EC6D7A0B6CBCA36968 /* QRCodeReaderResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8669ED437B4269BEA0E9FA54AACDF9A /* QRCodeReaderResult.swift */; };
+		7490339F96117697EDDB4CD81AC1A8E6 /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92CEF49FC2D0F46DDBF5F67D4400DD9 /* hang.swift */; };
+		74BCED1D4515510AEA3693709A473D84 /* BIP32HDNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C1B47B887904819BBE309C8F894E28 /* BIP32HDNode.swift */; };
+		7618195AD4D64CB705BD0F5A1F935C45 /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F4EA344939811A4346AE226D6D7490D /* BigInt.framework */; };
+		76A07471B25153C90BBE8C37CC9250B4 /* ChaCha20+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D9F663926E8B062E03E5DEE5432224 /* ChaCha20+Foundation.swift */; };
+		76DFD8D1994F9A566EE7137C454E6FF4 /* NSURLSession+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2A88C86693001FC598E4F8FE65448A /* NSURLSession+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7719D7A7A72CF0E40F9F89906821C42F /* Web3+BrowserFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC6C34F1EB41D1A5C278D510066904B /* Web3+BrowserFunctions.swift */; };
+		776B9137AF2C7FD457A0C977F3A944FB /* num_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C10B9EB6F4E1EDBF4259BA73B1B1345 /* num_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		77E8B7DDA613FB5C879784E0772FC013 /* BlockCipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2081C4B784593A557274AD122C985317 /* BlockCipher.swift */; };
+		78F2BC147CC813133D6356C9BE1ADCE1 /* AEAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467F795F6A9C3E0DFDD0FE46DFDC5186 /* AEAD.swift */; };
+		791173448CEA41EE22295C0898AAB52B /* NSNotificationCenter+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 4510A3501569C7B4E5F4871FD8A5C827 /* NSNotificationCenter+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		792EC6F4DB546922DD52D46D8523483C /* race.m in Sources */ = {isa = PBXBuildFile; fileRef = 2328858BB115D2308FE8B5AFFE824C53 /* race.m */; };
+		796177DE2762F24DAC16A709FD954838 /* ParameterEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EC6B707DF6C990C65CD05DA0301567 /* ParameterEncoding.swift */; };
+		79673D7F8AC2969E2BF8D3865AFA94A5 /* secp256k1.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D48A17683BDECE084550AA6339F9CEC /* secp256k1.c */; };
+		7E4895C66B5EFA4A944F8E0302D49E19 /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FE7D0E9CCED9C9CE1FBEE4A5253E1F2 /* after.m */; };
+		7E5C13FD0B0F002D59FB40E32118495D /* libsecp256k1-config.h in Headers */ = {isa = PBXBuildFile; fileRef = B2DE48CC3A2DFD167480E64360EA9259 /* libsecp256k1-config.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7E644BB890A7580698FAA02B380F08F3 /* Web3+EventParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9A701DEBB66A53F6A279814BAB217A /* Web3+EventParser.swift */; };
+		8066E1631B71F4FDBCCF460DF0484F46 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6017DE25135638C3828C30F112AB8975 /* Data+Extension.swift */; };
+		80B0B462C09D541D9E850D874D656673 /* CFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564EACCD48CFBD4ED24477096788B35F /* CFB.swift */; };
+		81C1FB472DAAF55ED66443EE6FF59E1C /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051DA8488AF7DF4EB56C80335B4E0AAB /* Updatable.swift */; };
+		8293BCC7B22412260873FB9EFD99FB53 /* PBKDF1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BCFDA3C56415A6D1EB95194CF8B592 /* PBKDF1.swift */; };
+		82B753C99B1998F9F8DD6C355D479880 /* NoError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52756545CBB2AEE411B9EAC53FEE5CCB /* NoError.swift */; };
+		847A155084AF3DCB445E53A1A33F2354 /* RandomBytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8593E76FB1B8AB27CB5F8CAFC9E5CE6A /* RandomBytesSequence.swift */; };
+		85165F01416D8F5A5DAA80BBFBBBAE1C /* QRCodeReaderViewControllerBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B551E8C7EDF19BDA8260EDB49E536F /* QRCodeReaderViewControllerBuilder.swift */; };
+		858EDADED0849F094E14AAA2D35EC642 /* BigUInt+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B153ADEBC0499C2F1A09B7CCF1CFED /* BigUInt+ObjC.swift */; };
+		875A8728A87183C01F95D896CB3CB41E /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DBBEE0989B31EB39158B86B75017F25 /* UIKit.framework */; };
+		87A29EE8951867AFBFF86FC496FBB0A6 /* secp256k1_ios-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CE1FBDE0FB577612625318231AE57033 /* secp256k1_ios-dummy.m */; };
+		88E5A2C0115C47FCC0F0BC1EB2A709CC /* NativeTypesEncoding+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894917C6A99D4E63593BC49A81275AA2 /* NativeTypesEncoding+Extensions.swift */; };
+		89128A20E6C8A058AF5679A461C06B74 /* ABIv2ParameterTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C227389A3CE55B031095EF269734DD76 /* ABIv2ParameterTypes.swift */; };
+		894FD1032DA7DA0E413336B69FC86B68 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CA91F2BD5FA1BFA7F689AD425A3FABF /* PromiseKit.framework */; };
+		8956888E1CC6894013EBC449101A3EBB /* UInt128.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C27A154651D4F380BA194E9F6FE8C89 /* UInt128.swift */; };
+		89FE93BB1568967A8E8518D0D58E3E4E /* TransactionSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24390439BA0255CEDE98DD9AE1B0C0BE /* TransactionSigner.swift */; };
+		8AD769BC9791E6C53FF3CD35554AA1D5 /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AF75932BDD1310CF0BE737574BB8EB /* PKCS7.swift */; };
+		8DBD7AF8E01CC48A4EC81E5A5BE40DC0 /* PMKUIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 502435EEEA3CAA6A5A83F0BB7EE5EBA9 /* PMKUIKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8DEAF2BC6728D500C85C317DBE4FADD2 /* scrypt-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C9AC7A31D4825C72086072BC767F4C1D /* scrypt-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8F354C0E7FF5211495179122C43BE627 /* secp256k1_recovery.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AC6A9765FDB4EADF4B8864803E1690A /* secp256k1_recovery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8F57DA42FAE238F2F32B0F41A512B35E /* field_5x52_int128_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E856872418F8844D28E0CBEA13BA203 /* field_5x52_int128_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8FC26FC4527AC222B1C2F40D4E1F3D81 /* Primitive Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2290B9A60E8498F813AE6510A42F13 /* Primitive Types.swift */; };
+		90102927AB42B3723962211F85E56805 /* scalar_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = DEA833EC1FB428657D0AFCA543D5BD48 /* scalar_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		901EB7C291CF64428DA601F703017F3F /* num_gmp_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BD777C11653A6C3DAA29269D27CEAC /* num_gmp_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		910DECB543C55FB96E09E4E2557A6755 /* Exponentiation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8175B9D465CE6E38ABB43A417B0416 /* Exponentiation.swift */; };
+		912BC4160525A37A44C8E052CFEB362C /* scalar_4x64.h in Headers */ = {isa = PBXBuildFile; fileRef = 101EE83D4F406DE2BC20E6ABE6A438C7 /* scalar_4x64.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9336E222FAD0A7FAE4B1F0FA18E81EA7 /* Dictionary+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9AFAD6A9F4E84A058F5A53D7377E0A /* Dictionary+Extension.swift */; };
+		948A42776191ADF279EA54B47486240D /* Promise+Web3+Intermediate+Send.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BDBFB5794940426BCD9BC3BEF8C03AB /* Promise+Web3+Intermediate+Send.swift */; };
+		94C78D2A4E635D01A9CD9986AC8CDD37 /* UInt64+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D685FF90DAA694471CB5BE3721EB71 /* UInt64+Extension.swift */; };
+		955032576272495217E22DC24330F5E4 /* BloomFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF6CEF45BF5ADAC2C2EE5B3F4563116 /* BloomFilter.swift */; };
+		965DACF3DC02857ECBE66C5CBA3DA5D4 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FA1AD549AF9033EB1C6ECC3198AAD8 /* Request.swift */; };
+		97C42E926597427B195C654502EDD194 /* Web3+Personal.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC491B89F0720A366015E66C7CC50C8D /* Web3+Personal.swift */; };
+		97CC2191FF1F5BF6E007E1F0452D3835 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7475B3B61C275359424F637C0994879B /* Operators.swift */; };
+		98037F51EA4A40D8EF580234D898372B /* eckey.h in Headers */ = {isa = PBXBuildFile; fileRef = 4745C274EF8239883C005C2A06EA7255 /* eckey.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		986B3829A2A2D6D9610048A002C39BC8 /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = BD64EE5E17635F522BEC667AE08BAB92 /* main_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		98C06B447E3A8A96B8B0B2BDEDFD33B0 /* RLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45748A876870FC089152EF8FD81E9A75 /* RLP.swift */; };
+		98C459EAEF81D101622627E37AAD0946 /* AES+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CF67230FE1CA91342AB81CEBB19158 /* AES+Foundation.swift */; };
+		98CB00EBFFCFBCAB10021D0E54135D9C /* secp256k1_ios-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = EAC3394F8A3EE59C59A9733F786B1306 /* secp256k1_ios-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		995E1CE5CC887714B3FBDBA9613DF04F /* num_gmp.h in Headers */ = {isa = PBXBuildFile; fileRef = E7D304295737E8DA2F6371A63E7DD0BD /* num_gmp.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9A683FAB2843A7181358FFC2F9AA7FAA /* BigInt-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D9C692C08213B8DB7387F7930D1365D4 /* BigInt-dummy.m */; };
+		9AACC7433B699B5CD9551CC03F97CBFC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
+		9AE3952131E530F55D34A350ECC9B909 /* Multiplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264A299CE22746F7C0CF181C6950609E /* Multiplication.swift */; };
+		9AEEE54DCA29801E2228D95001454313 /* Web3+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01852DFE34B287694A75EA0A355C3E5D /* Web3+ObjC.swift */; };
+		9C440121B1B2CB3D3D08D7221004F546 /* IBAN.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028415A0C2513E40239599F74C61D39D /* IBAN.swift */; };
+		9DA1244904AD9E535DFE95EC136A5799 /* Floating Point Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24CAA8870B6EBFE6E6833B8DD551BD /* Floating Point Conversion.swift */; };
+		9DC4AEECE8FF163D279EA1F988A68A63 /* EthereumKeystoreV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C20F6218D2D54CC76539F69C082B4E /* EthereumKeystoreV3.swift */; };
+		9E476BF8E453403A0507887A100A6755 /* PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E2FFE6E982290CFF29A826A4B438822 /* PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9E78BD9CDC348617DFD8E0E4622A3320 /* lax_der_privatekey_parsing.c in Sources */ = {isa = PBXBuildFile; fileRef = 05EC65CDE06E17433DBA29F7002C5EDA /* lax_der_privatekey_parsing.c */; };
+		9F7513BDB75539D13F0D1BEE170F3889 /* Promise+Web3+Eth+GetBalance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53462C3C917ABB5047BB31683E29A3C5 /* Promise+Web3+Eth+GetBalance.swift */; };
+		A04364B389BAE99BCEA1F86596D404CF /* CryptoExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A302CC286398A108E7231D64743135C /* CryptoExtensions.swift */; };
+		A063AF3BD1BDFFEE10689AAD1C93D80E /* ecmult_gen_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = CF3472CD4D6EC8A85F4709A83062E589 /* ecmult_gen_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A2359E6FA9743571581EA985032CECE6 /* ComparisonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF458B3B854F09D3F06D88AC6EAAC0EE /* ComparisonExtensions.swift */; };
+		A2A6097FE8255EE90F1F6DE2BE700404 /* lax_der_parsing.c in Sources */ = {isa = PBXBuildFile; fileRef = 7494F2FF241624C4C0B13986744BA168 /* lax_der_parsing.c */; };
+		A4256B5442606F51A40029AB6906C98B /* NSURLSession+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A17FFD11532E99A0E9F025F03D166F /* NSURLSession+Promise.swift */; };
+		A425AB2AFD2A6AC8C9AD47D474E8F964 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C54B58C29DFD97FBC7100505A8C2600 /* CompactMap.swift */; };
+		A436E789CD2ED7B08FC9B0D42A7DBC05 /* QRCodeReader.swift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 3860EA4942855E49A62C829717D8ECF4 /* QRCodeReader.swift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A534168E127BE842705C6148A8F522E0 /* when.m in Sources */ = {isa = PBXBuildFile; fileRef = C65CC5DD174B751E11B617617457C6AD /* when.m */; };
+		A5854512E9A95A355810514E30034C1D /* afterlife.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E442F38E92C044663A7567FEC0218DB /* afterlife.swift */; };
+		A5BCBD5220F048342AFA4AD373E41A51 /* num.h in Headers */ = {isa = PBXBuildFile; fileRef = 30FD6BFA988D38667768E1C7E6659270 /* num.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A5DF522FA056143C10A11DF0E191F747 /* web3swift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C052F06433005A8A6C466DFD2D5C585 /* web3swift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A6774EE973107CFC27CFEC8F9DB19B67 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
-		A68206C6C54CD653154FD56ACFB1DE48 /* web3swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 74C4F7726797CD7DABAEB28367A6E6CD /* web3swift-dummy.m */; };
-		A6B9BF2F0D5DEA52AC43A9863779A093 /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A79EC772E62A13DE0CD7323749B7E37 /* Codable.swift */; };
-		A6E056C2FC1C6B76B21733779D5E2E46 /* QRCodeReader.swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CE8979EDA54F76059818F7D9272FDDCB /* QRCodeReader.swift-dummy.m */; };
-		A765945680ABE1A73AAEF33A2D0ADC76 /* BlockModeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34002D3C3F98CE707F793AD0F71482BD /* BlockModeOptions.swift */; };
-		A8DD8450B62755340F32E75385672F49 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CDDBC20612961CC37CD4D522A380D3 /* Int+Extension.swift */; };
-		A8F867298C864CB03A598DB2B8D4A3A3 /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21557C62840B072F6EEAD19F0D2240B0 /* Thenable.swift */; };
-		A8F8960202BF10728388569A076CA5AF /* SwitchCameraButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9450BA0F46F30E624483F51BD75FC1 /* SwitchCameraButton.swift */; };
-		AA2A37518E86A0D2BF4FD2C5A6B82C6E /* field_5x52_asm_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = EA37580FEA73153CDB7822F775F2AD8E /* field_5x52_asm_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		AA65AD8A2647B7C8B13EE94715797770 /* AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 66912792AB23217C495C7D419F13EE63 /* AnyPromise.m */; };
-		AA7EAF7137C27D6E369D3F2E66ABCA18 /* Bit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8086578C0DC7EF0622EC041A26E4814C /* Bit.swift */; };
-		AB35A003CE80631DC7854597271FE080 /* EventFiltering.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3C5B8DD6E4101232857EDCFB29BA3B /* EventFiltering.swift */; };
-		AB8F7E4426BB517219518FEA4D2265B2 /* Promise+Web3+Eth+GetTransactionCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5D7F458AEE45A98CE2A88398BCB385 /* Promise+Web3+Eth+GetTransactionCount.swift */; };
-		AC6A460135DB70A59434BBFA75968FC0 /* Web3+Instance+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1609F2A0E3EB4DB99EABA47647E2DA28 /* Web3+Instance+ObjC.swift */; };
-		AC75879C79F55A175E7954CD3AE3D0EE /* Process+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9321D523FB42C52138CF67410DF7C696 /* Process+Promise.swift */; };
-		AC98E762CE8A8342E41A7DE3328D3FD6 /* ComparisonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88250D10A20EEB815A6E14FD5192E74D /* ComparisonExtensions.swift */; };
-		AD5370BA4B0DFB62DDB3A45E8A47DCEE /* EthereumKeystoreV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C45C929132142FE6689C2C4ED07BC5 /* EthereumKeystoreV3.swift */; };
-		AD705D761EB2B3E3C6E19E29AE8018CC /* ecmult_const_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F305D7EB0D67C4E7AA1642D028360C1 /* ecmult_const_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		AE9893361AA98D8A605B9E8219A44E33 /* ABIv2Decoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BA52C5917E5A43E50F5CFFA8520DCA /* ABIv2Decoding.swift */; };
-		AF40B6D3EA64E4492E39A28BE9711295 /* ABIv2ParameterTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BDC2A70C176E4B5CE53439F29006B0 /* ABIv2ParameterTypes.swift */; };
-		AF7191EC445198351E2396EED989010A /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DBEC6C530117F3405599A1A23356FF /* Collection+Extension.swift */; };
-		B0430DB0D1A212B1729DB5D7D247DD08 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F218A5404769FBD65244D21C4C1632 /* Resolver.swift */; };
-		B105CDBCFE2A0D83C1B09E755D979801 /* fwd.h in Headers */ = {isa = PBXBuildFile; fileRef = 67D0F512593FCE3F829AA0A99A087829 /* fwd.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B1096B673ECDFB6708A880F235F20281 /* scalar_8x32.h in Headers */ = {isa = PBXBuildFile; fileRef = 69520391266ED84E73AEEE018929DA2F /* scalar_8x32.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		B15A649BB6CC3D089394A30F991C601D /* Dictionary+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5D4088DE323E1E6B0D8585711F435E /* Dictionary+Extension.swift */; };
-		B172A8072454AB83995AF52101B03839 /* Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42AE7B67420B67F1EACEBB856F114C6 /* Padding.swift */; };
-		B1A2E4BB5C1D2ACB8E9E408D9B11C4E5 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FEB134F3E9ADEE9834D6CA22599A7C6 /* Data+Extension.swift */; };
-		B1C9A2AD55BC278D37D9EE61630C852F /* QRCodeReaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8452179E7393B2FA7CE61DE683FF7D73 /* QRCodeReaderViewController.swift */; };
-		B42395E589CAC70B11F08A597F10C9B7 /* Web3+Structures.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BECC646855C9D5F421B3EA83BF6EC9 /* Web3+Structures.swift */; };
-		B4DEABFCC90E8C5C59125B49A4EBCB7D /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793EAE17ACE0F873D75CC2FAF1AB96D7 /* when.swift */; };
-		B514B4E9DB02B1EC4321D62DFA0524A1 /* Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E1D36DD7AD259ED0E4D294C105AF4F /* Hashable.swift */; };
+		A6B9BF2F0D5DEA52AC43A9863779A093 /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A7C4F04F7073B982C3391CAD512EE2 /* Codable.swift */; };
+		A765945680ABE1A73AAEF33A2D0ADC76 /* BlockModeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA589F8FC69C78A18A71046F844CCF3C /* BlockModeOptions.swift */; };
+		A8DD8450B62755340F32E75385672F49 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5229EE3657A2EDF787D3C3D30FF03335 /* Int+Extension.swift */; };
+		AA7EAF7137C27D6E369D3F2E66ABCA18 /* Bit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FCC94DF64D415579856A46E9AE144F /* Bit.swift */; };
+		AA865C9CB2467587B15DBC682A081D0A /* KeystoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3153BA12BB5A92893507F8F2B04439A0 /* KeystoreManager.swift */; };
+		AE4F66AFE7D779053B2D58EEEB3EAE11 /* Promise+Web3+Eth+GetBlockNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = B774B455364008941BBBD9AE3C63743A /* Promise+Web3+Eth+GetBlockNumber.swift */; };
+		AF7191EC445198351E2396EED989010A /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC61D2173A7D897CEE43E9ED30B3858 /* Collection+Extension.swift */; };
+		AFDA8D13E690A68FF8B9C923A97BD466 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348A903FD4E883A5C775BEDF44449057 /* Result.swift */; };
+		B12AC1415BDCCDDD1D6EEAB56467CF55 /* UIView+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA911506B7BC5F109F11E624B3B58A9 /* UIView+Promise.swift */; };
+		B172A8072454AB83995AF52101B03839 /* Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917317E7E493C550E2E327E0D1616711 /* Padding.swift */; };
+		B1F5CCD9CAD4830DC4A9929384FBF546 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41102EF377C8CDAC35545F9584C7C182 /* String+Extension.swift */; };
+		B424F524BBBE34E685129945993809A8 /* Timeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B076EAAB85640AB48F8818F0C83657 /* Timeline.swift */; };
+		B43388A0CF1145AE55F05907115B6DE7 /* scalar_4x64_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 901D5132242D3951B5833E7F5E0BBB00 /* scalar_4x64_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B4945EB6B680B4FE40DFBBA3B4E70C0F /* Cimpl.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F6B987B7208100A40ED658C534AF947 /* Cimpl.c */; };
+		B514B4E9DB02B1EC4321D62DFA0524A1 /* Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4ABFDA4F6189C60A794986F555A9C0F /* Hashable.swift */; };
+		B60726775886A5470E682298753EC7FC /* Pods-DiveLane-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 664AEC560E1890D2ACDBD5C818D02E07 /* Pods-DiveLane-dummy.m */; };
+		B66A130B772B7A08CD6EE4C1EC4121EA /* SipHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 706D8E9400AC9ABEDFDCA0E98284A99F /* SipHash.framework */; };
+		B6858CAB7106EA19FCB3005E094BD31E /* LibSecp256k1Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AEA2DF1157620919DECEC2873190EE /* LibSecp256k1Extension.swift */; };
 		B6CCB228AB6B127FE1F963FDF204B2F3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
-		B7F3D476C87C0EC57139955A579FA3DC /* Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A182EFBD4BEB3EB8E3EAFFEBFCB4A07 /* Comparable.swift */; };
-		B8246291DF3891A83164B150E2E045C0 /* field_10x26_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = BB13AC3AB426E3CB418672CB306B578B /* field_10x26_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		B94EFD93F63D1FF0EC574918FACDE81E /* AnyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAADA0F39A44626A22386624E9CA132A /* AnyError.swift */; };
-		B97CC7C4BD5082A8E2B47BD5FD47DCB1 /* NSRegularExpressionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ACA44517F51EA28DB0C302D2051C522 /* NSRegularExpressionExtension.swift */; };
-		BA1FFC8A0A7634CC89B9BEC68B4BD625 /* BlockExplorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0221BBBC730C21F3F41B6255DDE12A4B /* BlockExplorer.swift */; };
-		BDEC4E13E67AB342D0FA893AC46B51FF /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99222AE65965EACC01E443FD9F22658 /* Utils.swift */; };
-		BDF04540F5EADFC8D25324EA6002C7E4 /* ContractABIv2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166DE5D1E7F051FDD9702B9C7A6474AD /* ContractABIv2.swift */; };
-		BE364FD8788A8019FE5F488F0F2360E8 /* Web3+Methods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A80FA1CCA53746C9DA607B2D8DEBD36 /* Web3+Methods.swift */; };
-		BE8889B9410CA6F7C7BF857151AAA2F6 /* Result-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D0C7941B416A9892CDDBD96789C132 /* Result-dummy.m */; };
-		BECE178E35105E0FFB592CD9AEC591FA /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714DAAE8E7D5ACDCCA832E4C597E499D /* Configuration.swift */; };
-		BF434DC19FC26804E361545DA07AABB1 /* SipHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 706D8E9400AC9ABEDFDCA0E98284A99F /* SipHash.framework */; };
-		C071946D94F30A19A067A2F37B699826 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DBBEE0989B31EB39158B86B75017F25 /* UIKit.framework */; };
+		B703BCABA6EDA5544D5C9423FED8F477 /* hash_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FDF73BA0AACCB5EA52DB51BCF9CE9C8 /* hash_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B77705737566AE83ED7E448923D7FA60 /* NetworkReachabilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736443A191D489AACD7786CE2779EE6A /* NetworkReachabilityManager.swift */; };
+		B77D59DD389486DB6F147D720DF7EB41 /* scalar_8x32_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BE47D22AA958D9CD94C0B7B99F0CA68 /* scalar_8x32_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B7F3D476C87C0EC57139955A579FA3DC /* Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3F9B931E5DF95AFAF706D8FA6CC55C /* Comparable.swift */; };
+		BBE610284DED27F26B953AF9A9E25E0D /* PromiseKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 823DAA23988145C04C357EBFCE95FAA4 /* PromiseKit-dummy.m */; };
+		BD1514F70A0EC11706BCA55444999FC3 /* ecmult.h in Headers */ = {isa = PBXBuildFile; fileRef = 256FDD8691B426343D2053D0BE86C4B1 /* ecmult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BDB125CFE9324E1F0A63709935117D1B /* ENS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706B73F36D2AA0D1FFC213721F48B3A4 /* ENS.swift */; };
+		BDDC293F508DEC2A9D3273D1C7EC6B44 /* Promise+HttpProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05C3368C5FD7ECC5190CD02861FC492 /* Promise+HttpProvider.swift */; };
+		BDEC4E13E67AB342D0FA893AC46B51FF /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3871425630F3D873F76F3BC235328D5 /* Utils.swift */; };
+		BE4BA1EDE444A770F834605F4B65348E /* AFError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7832791EE18B0023B28AAAC9039EE90F /* AFError.swift */; };
+		BEB5FA1DF2DFA9A16C62C78FDBEB0F60 /* BIP39+WordLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F41DA8948731CD42489BE7B783574EF /* BIP39+WordLists.swift */; };
+		BF3B3667BEDED5E979A4D30043B0C65D /* QRCodeReader.swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A58C40C1A7DB1C8A734F1436A9490FA /* QRCodeReader.swift-dummy.m */; };
+		BFA746D89DA91A8BB06B248A546C8EB4 /* eckey_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8882CE2764E4BE56DF60C9E9657CA9F3 /* eckey_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BFE36D2DD6CF7DD04BB1BB1E1AA17564 /* AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = E87751B2477DD5A23B5B37B8F2C022CB /* AnyPromise.m */; };
+		C143D6A2E0FB9DC62AC4410417222EDA /* web3swift-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 168C58A5F2EE3DA843CAD4C824AA0C52 /* web3swift-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C14B28E1B085DB351DDFC83187893EAD /* SipHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 706D8E9400AC9ABEDFDCA0E98284A99F /* SipHash.framework */; };
-		C14CE845EB0E0282DB7FCED8A4695A09 /* ABIv2TypeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147B6AEB73C3C9E8513DF4D79021E2D1 /* ABIv2TypeParser.swift */; };
-		C1E6617F404FF73114711159F727E280 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667F734F7FA99E745C2835EC2DA2C4BF /* Array+Extension.swift */; };
-		C39334762D97FFDF0ECF60FE78FEE593 /* HMAC+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EC6F414C91B379A64B34DAFBB3B3C9 /* HMAC+Foundation.swift */; };
-		C403A8648896F5F7AD57ADE45FD25551 /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CAC501877E70427E127EFA88E10199 /* Catchable.swift */; };
-		C40F08B54CA428A4D6A5196AB70AB370 /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FAD6B3A1AAE9F168F997480BD36871A /* hang.swift */; };
-		C466D2734F3AE12E8DEA1D0F6AC37CAE /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA6A2609AF99A1F3CA14B4A62E043AE /* Result.framework */; };
-		C6899540FF3A564EC36C0F5C8B803F7C /* lax_der_privatekey_parsing.c in Sources */ = {isa = PBXBuildFile; fileRef = FE43D491122858F762CB98C49FA1B1B2 /* lax_der_privatekey_parsing.c */; };
-		C73B1942236DECB83572F647B7BE40CE /* Promise+Web3+Eth+GetBalance.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF007536B0CAD11C81F81E5AEAEF96C5 /* Promise+Web3+Eth+GetBalance.swift */; };
-		C771193C744CC0069CB1661CDE5C802D /* AnyPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D19F9EAEF25529BF3F3B331F292817 /* AnyPromise.swift */; };
-		C7759B28E1875D57C36804662699C75D /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = FD59E5D486F37BD5BE6262B1D48A811D /* util.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		C91C350A9136FD770560AC2D13DC54DE /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41C3E6A280C712951F4529D21BF46A9 /* String+Extension.swift */; };
-		CAA32151B569F35FB5C22AEBA894EE1C /* ResultProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE657AF6DA9389F135A039CFFC4A748F /* ResultProtocol.swift */; };
-		CAF579CC2CED09FBDCE2864827B8A085 /* BigUInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98042B15E6438A1708C16E5D4E99EA2 /* BigUInt.swift */; };
-		CBA19A08C5BD25AFFEA9E7711B2CF8F2 /* Promise+Web3+Eth+GetAccounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F4E98031D70399B7BAA04C8BA36D16 /* Promise+Web3+Eth+GetAccounts.swift */; };
-		CCA302A346FC3E32900A3DA14F00B8BA /* KeystoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAAB7DFE95F896DE6A26D8D73762B632 /* KeystoreManager.swift */; };
-		CD13C27BEF9D398C0055D537003F0206 /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9E33D7B35D7414F58825BD46C796BB /* Cipher.swift */; };
-		CED4D026286893716F44C6DF7B378DD7 /* BufferStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50A145B512B01C48B19A84D643FB5DC /* BufferStorage.swift */; };
-		CF5CB139ED7F2044717593D9043A0ED7 /* UIViewPropertyAnimator+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFEF37D5BF463C9959B0164D3C71435 /* UIViewPropertyAnimator+Promise.swift */; };
-		CF6E429B7A206771952CA8D019D77E66 /* eckey.h in Headers */ = {isa = PBXBuildFile; fileRef = BF2B2DA5A2561B9D5D3EAFD2BD989D64 /* eckey.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D055E971D83B4EF001F8B0C05D40B422 /* Promise+Web3+Eth+EstimateGas.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4ACD9A5E6A4EF9A218662A89A9E5D6A /* Promise+Web3+Eth+EstimateGas.swift */; };
-		D1442524EC7DCB17F235E12B81114603 /* CryptoSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A91184E78522CDA56B22FF1EDB1C3AC1 /* CryptoSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D1485BEE11C35FCE70AE3DF82ECD7B4C /* Web3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D46CDF03C9910792DA563A596A1AA6C /* Web3.swift */; };
-		D1AAB08A2C4753E0BDA67647B824A4E6 /* BIP32HDNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2D8F7A44C9A04DE2232E3D77A120B8 /* BIP32HDNode.swift */; };
-		D28838224BE2A4676E92C7AD4DE160FE /* NSNotificationCenter+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = CA687D0E7D969684C006B6695B29A09A /* NSNotificationCenter+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D331038D5B32F2A318ED1E288AEECFE4 /* secp256k1_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA855DC6412290B5286A9DD3D5F8FA5E /* secp256k1_ios.framework */; };
-		D465365F819D9514B406031A0C845BAA /* CipherModeWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0756499BD68CE88386F1DDE23712AD /* CipherModeWorker.swift */; };
-		D51B75A3AF47900D622D415FC229E027 /* Promise+Web3+Eth+GetBlockByNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35D3B343A717FCDB8D4F958E8312BED /* Promise+Web3+Eth+GetBlockByNumber.swift */; };
-		D565D2C588403310E559D66C16B34801 /* secp256k1_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = 4317C6AE4C3DCDDA7D41BD55C5B5FC42 /* secp256k1_ios.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D57FC0427FCBBA88B4CBFF5E8EB47A2B /* lax_der_privatekey_parsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 83F67535422CCA74B29B5F1CE1572FD2 /* lax_der_privatekey_parsing.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D808DA8AF0A2365679F4A8AE8D470F3F /* ecmult.h in Headers */ = {isa = PBXBuildFile; fileRef = 01EE091A06FF9586084A85DE0118B82C /* ecmult.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D953DA4479CC018FA143BF59E7A5B10A /* ZeroPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C939D64636F1F2FFF721FDE6005F2F0D /* ZeroPadding.swift */; };
-		DA15C3B185171BD6E5F97A26C60FED2B /* Web3+EventParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6522C7D53C4ED1BCB2C616D342D0C211 /* Web3+EventParser.swift */; };
-		DA5B470FFD674D60426F8B3343B5DE76 /* Promise+Web3+Eth+GetTransactionReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1259AE93B24BF01BEE804884A4F978C5 /* Promise+Web3+Eth+GetTransactionReceipt.swift */; };
-		DB09CB5BA015B9F340ECF790D20AB58C /* scrypt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39ED000938F638B38685F1C7D5E22786 /* scrypt.framework */; };
-		DB30A42F75E28F7EFA26F29028A696A2 /* Web3+Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D095D938B024427A74E17FEFDC681E /* Web3+Protocols.swift */; };
-		DB3AA3B2747DE3DA344F88727E0792D7 /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B887CA868DF2DE1DB203D6F4FE718AC /* PKCS5.swift */; };
-		DB82D0A6866EA4EFEFC9EB995DEFE411 /* EthereumFilterEncodingExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 760710F8F0DCFBEE321D645FC9EC8799 /* EthereumFilterEncodingExtensions.swift */; };
-		DBD5D46970B589C74A1FEAAFFBC1744B /* StreamEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBB7522F3404A3011852D8BD477968A /* StreamEncryptor.swift */; };
-		DBE0389A6B1CB1210587983AD0732F93 /* Promise+Batching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB37EF90329DC22848705FF392DE561 /* Promise+Batching.swift */; };
-		DBFE03BADBBA9AA12AF693CBFCE7BC43 /* scalar_4x64_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 9109844DAD13D5EA4994FE47EAC8E7B6 /* scalar_4x64_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		DC206B17FBAFF044B6170E3826E327B1 /* Scrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB998FAD907A6E5DFD87374AF7CA9D4 /* Scrypt.swift */; };
-		DF98911B0F87E37CA61A850651CE7EFE /* GCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7E1C14BBBF779E4B6B5F784AFCFAD7 /* GCM.swift */; };
-		E03BD5674EE0D0937519FD3B55F2BBCB /* NSObject+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3A83C2569B2AEEA18325963C025108 /* NSObject+Promise.swift */; };
-		E058CDF8AC170914C28E1A9F88FFE479 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
-		E0D532279F8653339587E76E19281271 /* EIP681.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD3729C3876B97234310E3E81099B8F /* EIP681.swift */; };
-		E1A425C63B72CE7036F945291C1ACBCB /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30F1C78CB74595997600FCDFFECFD859 /* CryptoSwift.framework */; };
-		E1E2F0F5B7C9AEBCB8A473C861A0D35E /* RLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61B9122E3779351D03DFD6CAF5B0D6E /* RLP.swift */; };
-		E2F49DCF776B189057E13990400C3EA8 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C2948CBB2860088420738DCCAFEA2F /* NoPadding.swift */; };
-		E32D48366A58DE25C17441CC89C3B2F0 /* when.m in Sources */ = {isa = PBXBuildFile; fileRef = C57101628C8EDF06BC7342A48269104D /* when.m */; };
-		E38307483197EA2E6C7955C6FD1997DB /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F4EA344939811A4346AE226D6D7490D /* BigInt.framework */; };
-		E4FC94AE7C56A7ED8954F5AD1E4FE46B /* Web3+BrowserFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4499FB78EF2CA976271E1DD561F132B5 /* Web3+BrowserFunctions.swift */; };
-		E70470EF1B27F26E6E272126FD06EA88 /* QRCodeReader.swift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F544D2A20CB42C44EBFB2EE25824C5D /* QRCodeReader.swift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E80977D7F30E52B0A151AA3284FA0EA6 /* NSTask+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 0108F32F1505C2F0BAFD2DE18FBBECE2 /* NSTask+AnyPromise.m */; };
-		E82F15CE10FE5291F3346A78F11EAB71 /* BlockDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AF320F445F837D3DF7F3CA83C7E676 /* BlockDecryptor.swift */; };
-		E89A64C0B4C4EEBC0BE855773078E283 /* secp256k1_recovery.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CC5946A47DB0731B068118DF7AD545B /* secp256k1_recovery.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E8CA9824DFEFDBE5FC430276A237F97B /* Data Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC1B01C1779486510931BD394A8BDF9 /* Data Conversion.swift */; };
-		EA98D6932D6F09CAB0B6D5DC0032B73B /* num.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CBF4DD2E9E2CA1D86037728AD0551A2 /* num.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EB10FB84711D4D320F14A9D18A016CDE /* Web3+Eth+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D1682813F759C273A31C2B4B5C5A95 /* Web3+Eth+ObjC.swift */; };
-		EC69A07ACD1A82BBDC82246FF91B5001 /* TransactionSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03433D7E52F91A51BFA94E64D405A26F /* TransactionSigner.swift */; };
-		ED7B7C502B11EAF1580EAE8236F1D010 /* race.m in Sources */ = {isa = PBXBuildFile; fileRef = 34F48B3606186F56C547BBAC70FE9E42 /* race.m */; };
-		EE1315428CC555F10FF79748B7ABC406 /* field_5x52_int128_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C267C22945AF26C33C325CE17070F06 /* field_5x52_int128_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EE851A358B5CFC5DB55B649D4E0F6817 /* String Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EAE8C76427A933698DEB3D56A3427A /* String Conversion.swift */; };
-		EF356C7DDED17BC6D39CCB104D731668 /* field_5x52_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ABEFEDF0B2C2DAE50EE05965F4F2763 /* field_5x52_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EF63D72E24508A3F66501BDD4AA9E6C5 /* secp256k1_ios-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 781D6EBD207326333AF47A6E96B0513D /* secp256k1_ios-dummy.m */; };
-		F0AC9F138AA0272B3B7812346EDAC741 /* PKCS7Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C238D4F471736091D3722367119066 /* PKCS7Padding.swift */; };
-		F1631F5F7CD77D9527E4FE5EEFBCEB3D /* BigInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6107660A564CA761AD2EE8C3D92E78 /* BigInt.swift */; };
-		F2F1B2110BA70AE5A85FA0A8519F0A20 /* scalar_4x64.h in Headers */ = {isa = PBXBuildFile; fileRef = F58BDDA276A7BE795A0ABE5B5DB9B775 /* scalar_4x64.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F41DE1A38B6ECF011127CC2F18B8F1E5 /* Array+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97A5FA3F03B5FC2E2E8D181D2D00D06 /* Array+Foundation.swift */; };
-		F55E7AC1BB87A003556D9F217407EEC9 /* Result-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 721ED87D8D0B64B0CFE26E691A3626E1 /* Result-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F62CB020347D65CE57D6CF01B00D84AA /* UInt16+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0CCD3ADD8A757A11862385A5B31AF4 /* UInt16+Extension.swift */; };
-		F6B21DC973E10523629435FD699B1D18 /* secp256k1_ios-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C9AAD1576095621D68E0542F640A916 /* secp256k1_ios-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F6F92FC558F75F2BB7F688AF5645090E /* ReaderOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5427CACBC2CF16837E0169F9898C09 /* ReaderOverlayView.swift */; };
-		F77CB59BF3A7FE0E4B364AE760E2D69E /* NSNotificationCenter+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = C542891C63483A08B0BE169BA765C23A /* NSNotificationCenter+AnyPromise.m */; };
-		F79164F06C90C81A48EB83EE0AB5F761 /* SipHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714A2D37F8F87E883F046D7828AB6D98 /* SipHasher.swift */; };
-		FA1E1886C06F92EC076CBDA943C753D6 /* Promise+Web3+Personal+Sign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE69ED3CCD20098717723EC70FBA476 /* Promise+Web3+Personal+Sign.swift */; };
+		C1E6617F404FF73114711159F727E280 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F095D6675E92DB361EBD6ED6641597 /* Array+Extension.swift */; };
+		C34917429A6F19D2B2FB285E7AD39BA1 /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38BB6B56E3E88A1D6E48D0DE5D6364D /* Guarantee.swift */; };
+		C35FC2CAA12EEC4254D722CBE07F9E83 /* QRCodeReaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B28B0A2B21362D0A9AD85EA2466BDC5 /* QRCodeReaderViewController.swift */; };
+		C39334762D97FFDF0ECF60FE78FEE593 /* HMAC+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DA4F4135D16F7846D98A5D136594EB /* HMAC+Foundation.swift */; };
+		C71644D36145840EBC3987260942DA98 /* ABIv2Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD300E1DE0EC70FDA3B58AFBF0BDB0D /* ABIv2Elements.swift */; };
+		C95D35DBE08B6B16472568FFB985931F /* BlockExplorer+GetTransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09530693B905CFC7A6FDC129C4FF9BCC /* BlockExplorer+GetTransactionHistory.swift */; };
+		C990D358833D46262AC60E273E82144D /* field.h in Headers */ = {isa = PBXBuildFile; fileRef = ADAB8FD05505F6681B106032F4D674DA /* field.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CA5050CE99378FD06459D795FD59971B /* Process+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B719F0183CEE01B32C1F07763F2613A /* Process+Promise.swift */; };
+		CAD31C705E326EE53F54CDB408182774 /* web3swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 56F399204F0B76DF92B22D4221126C0B /* web3swift-dummy.m */; };
+		CAF579CC2CED09FBDCE2864827B8A085 /* BigUInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D9A86A09328B52065F37F62B0DA725 /* BigUInt.swift */; };
+		CB305592B499886BBD819BAFFEC2245D /* Scrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA7EC0C1DB8C4EC5D96730BBACB27B1 /* Scrypt.swift */; };
+		CC5FC7F90798330B302EA7B4AF4C49EB /* EthereumAddress+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B623A2B8697B4678F96B21A6B722FC6 /* EthereumAddress+ObjC.swift */; };
+		CD13C27BEF9D398C0055D537003F0206 /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B979C8BAE317028F54D235D2A0CF1BC /* Cipher.swift */; };
+		CD629CC9DC61557B57F9728AE2EC57F9 /* ToggleTorchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AA68A9D6621F4FA5B468BAFEA1D19A /* ToggleTorchButton.swift */; };
+		CF92FCDE194E8E24CCD8D08D893DC1AA /* hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 88F992F8D3048AAA721EAF25366808A9 /* hash.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D0A150A0EC5E378336C4336372553DCE /* field_5x52_asm_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = BD68A36110A4FCF3C1583F018F78F1FF /* field_5x52_asm_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D0AD4F096F2C952FB827283A1E3C6407 /* QRCodeReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B177EA78A9BB9FAC15ADA59CB21E85 /* QRCodeReaderView.swift */; };
+		D1442524EC7DCB17F235E12B81114603 /* CryptoSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 92A558EE489C6417A46A979E39DCE1BD /* CryptoSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3330EF1A553775BEC5A72B5C20F0E69 /* Promise+Web3+Eth+GetTransactionCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E135D280E58286565605E0EE6CBA253 /* Promise+Web3+Eth+GetTransactionCount.swift */; };
+		D465365F819D9514B406031A0C845BAA /* CipherModeWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313120D6B0844C95111E1650DE5B68E8 /* CipherModeWorker.swift */; };
+		D4C3899574E9D5DF5E5DA52310560BCC /* Alamofire-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AF08B8DF071710D784EFFB10758809CD /* Alamofire-dummy.m */; };
+		D6234C479ACD00C74CBF73EE58473AA8 /* group.h in Headers */ = {isa = PBXBuildFile; fileRef = E713368D9AFBF25CF62922ABCCA8103F /* group.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D7CC4B991421163CC89AAE744074033F /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E5CCF0E45CEB1373D954DBA4B4A322 /* after.swift */; };
+		D83CF28C0050E1A5BAEB46C5F0703F66 /* scalar.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BBF9DAE2BE96268A66EC11337DE66CE /* scalar.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D89B9A01F381C5D8386EA90FFF15C6E7 /* SwitchCameraButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9E9F05A9B792E0E91D36873C906C0A /* SwitchCameraButton.swift */; };
+		D8CBB683C91FFC751090C3C9340EEA97 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
+		D8EC5B74B9B5DC842F4179D19E6DE6D4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
+		D953DA4479CC018FA143BF59E7A5B10A /* ZeroPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244B6FF4B1380D326D4C5E6F093CEB7A /* ZeroPadding.swift */; };
+		DAF528C5641C86802C739097EFA52C85 /* UIViewController+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 63CA4DD74FB0F34DA9088C2DD00A6C7D /* UIViewController+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DB3AA3B2747DE3DA344F88727E0792D7 /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFA1AE34EF824D45F5201833B299CFD /* PKCS5.swift */; };
+		DB932EBD83F5AC0528C88D3708AB239C /* QRCodeReaderViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8796A6C08F8592D9CE812BD9B184C87 /* QRCodeReaderViewContainer.swift */; };
+		DBD5D46970B589C74A1FEAAFFBC1744B /* StreamEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD339B1454B79A6400983A439AF3AE02 /* StreamEncryptor.swift */; };
+		DBE6E2E4D205545E7988CFA5057C31D6 /* DispatchQueue+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D018E84EED83CC3078FCCD3270F2ADAF /* DispatchQueue+Alamofire.swift */; };
+		DC7CAB8E9A0A5DF69D861A9096AF2B0E /* Web3+TransactionIntermediate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353695A952984817097B654FD92DDFCC /* Web3+TransactionIntermediate.swift */; };
+		DD730775E0AFFAD27A1EAB4372F9FB51 /* Promise+Web3+Eth+GetBlockByNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E41E2D43AA4B11B56B0F45BBAC5738 /* Promise+Web3+Eth+GetBlockByNumber.swift */; };
+		DEB0BD83C9FD93BE95FB843D41E1FEFC /* NSRegularExpressionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0B56AB8D88FE4DE6C230ACD3C39D54 /* NSRegularExpressionExtension.swift */; };
+		DF619245645A2412DDAFEADBECE520F2 /* NSURLSession+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = E10FEED15925304FB7969ECED0F6F76E /* NSURLSession+AnyPromise.m */; };
+		DF652161003AED72FD7FC2FAAB5C5E39 /* PromiseKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BBB2E83B0870410A5D08B5DF62BC0BB0 /* PromiseKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DF98911B0F87E37CA61A850651CE7EFE /* GCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F5EF4474394372C33D5AD7DF8A0065C /* GCM.swift */; };
+		E2AC6A5E691454B1B4D9FFBE7B7C3FCD /* field_5x52_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = A8D72BD9A6E8FD6F0F5846DCD6B06878 /* field_5x52_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E2D177E7B987881BB0AC79A55297C3C3 /* lax_der_parsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C41C40F3239FB7F59F4EBEB0A3511D /* lax_der_parsing.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E2F49DCF776B189057E13990400C3EA8 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B60815E6AF7C1CE2B12FD7EF5E935D /* NoPadding.swift */; };
+		E3A6B2EFFEEB0D63342BE773E35B7613 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C97902182015B3601CE10E1F25CE34 /* firstly.swift */; };
+		E466D230D23EFBBF8491C80407FDA362 /* web3swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F6F2F013DE7F8622027C3569BCF1A9A /* web3swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4DBDFB182A70FBD2DF63EB85315BCCF /* Promise+Web3+Eth+SendRawTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E916781CA2BA06FB627485A88EFB61 /* Promise+Web3+Eth+SendRawTransaction.swift */; };
+		E68622C1CC4BA4F54ACCCEBD134A648D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
+		E6CB085901BB43D49AC12B1FB6081269 /* field_10x26_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 341304168E0921272AD3C19EC05F5B5F /* field_10x26_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E824C0A2F6DF39E7FB967C0E94C551A1 /* Web3+ERC20.swift in Sources */ = {isa = PBXBuildFile; fileRef = A523F91DD68A69492E50FEE51152D552 /* Web3+ERC20.swift */; };
+		E82F15CE10FE5291F3346A78F11EAB71 /* BlockDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCF6AEDC0537776CE0D24F9F130750D /* BlockDecryptor.swift */; };
+		E8AF3C9FA340B6C84D3849E32F10BE92 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA6A2609AF99A1F3CA14B4A62E043AE /* Result.framework */; };
+		E8CA9824DFEFDBE5FC430276A237F97B /* Data Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FD914ED903081DB2FE4C26E38D3865 /* Data Conversion.swift */; };
+		EAD457174113111A9446C871DF80A290 /* PlainKeystore+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB6967D78BDD324F6C6F7152A13DCF3 /* PlainKeystore+ObjC.swift */; };
+		ED472B0E1D15ED108378BC403DCC823E /* secp256k1_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F29B0076CE93A7FC836359D228078A9 /* secp256k1_ios.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		ED544BB12791C4C01CF6E523B96C8A62 /* ABIv2Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D8E7890E553410A109389CB2B47FAFB /* ABIv2Encoding.swift */; };
+		EE13C80520635958874DC8A103A71791 /* field_10x26.h in Headers */ = {isa = PBXBuildFile; fileRef = B4AAF8307C81ED675D28AEDEAA3CA402 /* field_10x26.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EE851A358B5CFC5DB55B649D4E0F6817 /* String Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2CE11C62E522B7B555D073C66C724 /* String Conversion.swift */; };
+		EF1461221681BCA12A4147900A704727 /* Alamofire-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 01CF0F29ECE5A077234420623654BBBB /* Alamofire-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EFD36171DFE635C56C71796AF7638EA8 /* ecdsa_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = A88E1E37AA32CDBC72132AC7BDD7FE7B /* ecdsa_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F0AC9F138AA0272B3B7812346EDAC741 /* PKCS7Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5231B7A7C9D35B5D55A46943A58E7FD /* PKCS7Padding.swift */; };
+		F0D4106B516969DDCAFCAC598DA3571E /* Cimpl.h in Headers */ = {isa = PBXBuildFile; fileRef = A728C96D2D6447B46FB27C5908606294 /* Cimpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F1631F5F7CD77D9527E4FE5EEFBCEB3D /* BigInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693BFC0D19556FFCE33111EA56CCAC03 /* BigInt.swift */; };
+		F242996490BC1DB2FEE2EB78AFD9EE13 /* join.m in Sources */ = {isa = PBXBuildFile; fileRef = 31DC89BD1E950F19A4B697E65EBC702B /* join.m */; };
+		F2454DABD30D051691C20C1A5BB30DE0 /* scalar_8x32.h in Headers */ = {isa = PBXBuildFile; fileRef = 96803255870FC0B988C5D3FF3EC38DF5 /* scalar_8x32.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F2A62A1DCE28373F93FD3AFCF0032E03 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418047EC2D5B05083EEFC267F36DFF2F /* Array+Extension.swift */; };
+		F41DE1A38B6ECF011127CC2F18B8F1E5 /* Array+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C4E22693024283CEF1CE5EC99BFEF1 /* Array+Foundation.swift */; };
+		F4DF280F691068BCD3DC0BB5631D4E85 /* Result-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = AAECC5EB37FA21B358456B45631F17FF /* Result-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F5835978C09B666E35587CEDB171D57D /* Promise+Web3+Eth+GetBlockByHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229BC0CAF8AD47BBB98F8626C188F13D /* Promise+Web3+Eth+GetBlockByHash.swift */; };
+		F59CE65ADE4353A52F9316E6F0F4D541 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E8202B9346F8FC67DC758394515FF8 /* race.swift */; };
+		F5DC5ADD3B52C79B705C8606FF26BFE4 /* Web3+Methods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9E7E3492F16CF045775D93AEF49A94 /* Web3+Methods.swift */; };
+		F62CB020347D65CE57D6CF01B00D84AA /* UInt16+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1E41FC7CE889C03F43819CAC906CC /* UInt16+Extension.swift */; };
+		F79164F06C90C81A48EB83EE0AB5F761 /* SipHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4AEDF255D6A629E1A280179E5A7A5A /* SipHasher.swift */; };
+		F854349B3765620110B7B718A7CD10F8 /* Web3+Eth+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836ED2ADDCB705E25214F2432D3EDE48 /* Web3+Eth+ObjC.swift */; };
+		F945087BB7909A6A01BE0658CAB5A013 /* NSNotificationCenter+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B484180C55627FAAA803F7EE2DCEAB /* NSNotificationCenter+Promise.swift */; };
+		F9CA45B6C064700E89542DF66C9290B7 /* Promise+Web3+Personal+Sign.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9361D2F2F5838E6646F06E68392D728 /* Promise+Web3+Personal+Sign.swift */; };
+		F9EA61D484CC15FDDAB0D8C0D26D7949 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C2E683987F15936DEBBB1187F7DB51 /* Result.swift */; };
+		FA4390D046D496FCAF883D359C752835 /* Web3+Instance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99978E9C44BDF8277225A7AD3CD7D0E6 /* Web3+Instance.swift */; };
 		FAF78D494C90276099BA6AA47428EE5C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
-		FC471107E99701BA9650C2F5C28F7E2D /* EthereumAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75A2DBD7913BD159F4A5A5069428A96 /* EthereumAddress.swift */; };
-		FC7516970C002B119C35BDD3FD2092CC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */; };
-		FCC4CAEEB081254048F9F8EAD95E0B08 /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A11BABC7FF560066D62BD1E5688FC7 /* Generics.swift */; };
-		FDB4C331D31F49C704C2FDEE5E613066 /* Promise+Web3+Eth+GetBlockNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308BEE6F5CCFBDD8FD9BEBF131AB4E0F /* Promise+Web3+Eth+GetBlockNumber.swift */; };
-		FEAC80B941FF2C804D997C2DF64765A6 /* QRCodeReaderViewControllerBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1B25B4A57B80C024DAF4169CBD5738 /* QRCodeReaderViewControllerBuilder.swift */; };
-		FF8D6F9246B91602A6510889F5AC7A37 /* CTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9334E5543C9956623D4BFAA9E0560258 /* CTR.swift */; };
-		FFBA8696A49B49BA33D1499546FCEC58 /* Shifts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454398613D40E174051C0EC0F05B4B27 /* Shifts.swift */; };
-		FFE76E41B1237942FE51F1B5D42CF077 /* basic-config.h in Headers */ = {isa = PBXBuildFile; fileRef = 95DDFD2F47B41B96FBDF82BB79C4DA9F /* basic-config.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FC6375EF65F586FCFDF63C3CBD1B30CB /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60D5B76E28C82511B6EF078E996882C /* Resolver.swift */; };
+		FCC4CAEEB081254048F9F8EAD95E0B08 /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96BEA8AB7CDEBF6D2FFB21A021A7E8A /* Generics.swift */; };
+		FCE6F0C6E44CEB492EE435F1E59C332C /* Web3+Eth.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C3B59AB29207F987669AFD77BA598F /* Web3+Eth.swift */; };
+		FE108BCA4DE52F0967F3B3F9A81BF967 /* EIP67Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA82B8AB03FC2F59B88A0669833A7ED /* EIP67Code.swift */; };
+		FEBFAC04167363A7EA8029822BB299D5 /* EventFiltering.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A288328F7FF4DE93CFF3FDDDE072D3 /* EventFiltering.swift */; };
+		FF8D6F9246B91602A6510889F5AC7A37 /* CTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72B89AF39754D5394CDDA89EF1FE910 /* CTR.swift */; };
+		FF9C7BC64DB23D2CED48197DE67F0335 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DDF980766BE47F9321CB1912ACC7791 /* MultipartFormData.swift */; };
+		FFBA8696A49B49BA33D1499546FCEC58 /* Shifts.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2467C8F75C056D0510A2DC383174166 /* Shifts.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0A4EC11D0E56665855E79F832BD5523E /* PBXContainerItemProxy */ = {
+		0216552AFC35B881CD5BA3173367F6B3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7FF8752D2607B0617A8EA59CB6F52DA7;
-			remoteInfo = SipHash;
+			remoteGlobalIDString = 4DACDE493E99BF92E5758A59F946A750;
+			remoteInfo = CryptoSwift;
 		};
-		0AC7F1D783910203391A096BB44AFE48 /* PBXContainerItemProxy */ = {
+		026F18226FF47CED6CF4C0EB22D192BA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2CF7A076E9162EBB8228CED135E7C18C;
+			remoteGlobalIDString = E6336E5011C07ED0B898E35CCE6962BC;
 			remoteInfo = Result;
 		};
-		0E2892B5FFA632E668E8418208290F0E /* PBXContainerItemProxy */ = {
+		1295E2C5375438A1EA3E9B89CD31A1B9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 4DACDE493E99BF92E5758A59F946A750;
-			remoteInfo = CryptoSwift;
+			remoteGlobalIDString = D1FD0E21E3FCF9A519A66590CEEB2A0F;
+			remoteInfo = QRCodeReader.swift;
 		};
-		1350D05DA9F9A6D6B1A2D654E8453D08 /* PBXContainerItemProxy */ = {
+		1BF4983F7D57B18FFD797186BBF98793 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 303167748906E66A0A80381A36E3854B;
+			remoteGlobalIDString = 84B155C6F720EBFA5F1E099374CD6337;
+			remoteInfo = web3swift;
+		};
+		207E64C251DF0422512B72A0455FCC12 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1C9AA7A4B8F37D8E5F4B43B22D1EF8A3;
 			remoteInfo = PromiseKit;
 		};
-		27677CBF19E248690987A98F05DF010F /* PBXContainerItemProxy */ = {
+		41C4CBC2259B5CB77167C1D04B3CF780 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 4DACDE493E99BF92E5758A59F946A750;
-			remoteInfo = CryptoSwift;
+			remoteGlobalIDString = E76458C58C9140B6A16D60547E68E80C;
+			remoteInfo = Alamofire;
 		};
-		3320856BDDB3B8FC631B9197BC0F3425 /* PBXContainerItemProxy */ = {
+		4CDF31E448E66C4116679E964AD4A2DD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7FF8752D2607B0617A8EA59CB6F52DA7;
 			remoteInfo = SipHash;
 		};
-		6AE1E210BA97E2EEEF9C377464884C0B /* PBXContainerItemProxy */ = {
+		563B47278A0942617A66E48057B56B48 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1C9AA7A4B8F37D8E5F4B43B22D1EF8A3;
+			remoteInfo = PromiseKit;
+		};
+		5A44B36ADD52645ACBC8C7DC792BC5B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 32E40FFD4C55CDF795FA4DF41F2DFF83;
+			remoteInfo = secp256k1_ios;
+		};
+		6B38882EB21F2C8D8330F7B7F14F9ABB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E708490E977C6CAD49A6D120BFC83DFC;
+			remoteInfo = scrypt;
+		};
+		75BECA4ACE5F992A3800555500F7FFFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7FF8752D2607B0617A8EA59CB6F52DA7;
+			remoteInfo = SipHash;
+		};
+		945D1A49FEE51625B075FCF160E24E7C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4DACDE493E99BF92E5758A59F946A750;
+			remoteInfo = CryptoSwift;
+		};
+		BF7F3669B64C047A101458F54D7E440A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4DACDE493E99BF92E5758A59F946A750;
+			remoteInfo = CryptoSwift;
+		};
+		C15C087EB5B719D99BC9EDAF7D0F18F4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E6336E5011C07ED0B898E35CCE6962BC;
+			remoteInfo = Result;
+		};
+		C53873A0B3680AD230A5BBAFCC4F7A3C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 137411A4D3CCDCAE6EE1A79271E0889C;
 			remoteInfo = BigInt;
-		};
-		77C40BC9CBE387BBDEC10012A0969514 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4DACDE493E99BF92E5758A59F946A750;
-			remoteInfo = CryptoSwift;
-		};
-		8A28B4E981EFFD5D5775CCA48395951C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F7A2AAC98407D026E81FB4955A54AFD5;
-			remoteInfo = QRCodeReader.swift;
-		};
-		9BC5CA57C59D9CF1B13BE5C4DB9C5433 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 303167748906E66A0A80381A36E3854B;
-			remoteInfo = PromiseKit;
-		};
-		A3D5DAD1763E4E6923BF969C818CE266 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 66D012442239182123EE1AFADEB46664;
-			remoteInfo = secp256k1_ios;
-		};
-		AE770EAC881F63B06508DC2630595F5A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3ED75BAF4B79F70F0C3833AFA7DF49AD;
-			remoteInfo = web3swift;
 		};
 		C6C17D0086F8D9E70B8AF619657FF2BC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -446,444 +487,454 @@
 			remoteGlobalIDString = 7FF8752D2607B0617A8EA59CB6F52DA7;
 			remoteInfo = SipHash;
 		};
-		D8ED359090D8E6308F80F32E1CE50A8F /* PBXContainerItemProxy */ = {
+		D5513F654B044E90CD48552BAB2707B9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2CF7A076E9162EBB8228CED135E7C18C;
-			remoteInfo = Result;
+			remoteGlobalIDString = E708490E977C6CAD49A6D120BFC83DFC;
+			remoteInfo = scrypt;
 		};
-		DD0CC46BE29772CB5FBF7B15CB37F15E /* PBXContainerItemProxy */ = {
+		D64CC56D19627E119942DE28E4BA1341 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 137411A4D3CCDCAE6EE1A79271E0889C;
 			remoteInfo = BigInt;
 		};
-		EA10A671767DF4FEBB0072E1BEE9A125 /* PBXContainerItemProxy */ = {
+		FD583C21E0767AC03D6C2C062CFCA80E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = C70F37C85E26F4DC361D08DABC1D2308;
-			remoteInfo = scrypt;
-		};
-		EB1C268B148714FBC899190875F55A93 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 66D012442239182123EE1AFADEB46664;
+			remoteGlobalIDString = 32E40FFD4C55CDF795FA4DF41F2DFF83;
 			remoteInfo = secp256k1_ios;
-		};
-		F7D5BE6737E68DA11F3206217531CA1E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C70F37C85E26F4DC361D08DABC1D2308;
-			remoteInfo = scrypt;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0108F32F1505C2F0BAFD2DE18FBBECE2 /* NSTask+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSTask+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSTask+AnyPromise.m"; sourceTree = "<group>"; };
-		01EE091A06FF9586084A85DE0118B82C /* ecmult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult.h; path = secp256k1_ios/src/ecmult.h; sourceTree = "<group>"; };
-		0221BBBC730C21F3F41B6255DDE12A4B /* BlockExplorer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockExplorer.swift; path = web3swift/BlockExplorer/Classes/BlockExplorer.swift; sourceTree = "<group>"; };
-		03433D7E52F91A51BFA94E64D405A26F /* TransactionSigner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TransactionSigner.swift; path = web3swift/Transaction/Classes/TransactionSigner.swift; sourceTree = "<group>"; };
-		04E1D36DD7AD259ED0E4D294C105AF4F /* Hashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Hashable.swift; path = sources/Hashable.swift; sourceTree = "<group>"; };
-		050032CBDB96B47020EE0C79B908B9D4 /* Checksum.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Checksum.swift; path = Sources/CryptoSwift/Checksum.swift; sourceTree = "<group>"; };
-		0564D106B866DFD63A27D0AE1AC7AA21 /* Web3+JSONRPC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+JSONRPC.swift"; path = "web3swift/Web3/Classes/Web3+JSONRPC.swift"; sourceTree = "<group>"; };
-		0602B443D4A90F45A146F9DF0317539F /* PromiseKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PromiseKit.xcconfig; sourceTree = "<group>"; };
-		06689683269F5BCAE45322E0E2E5B38C /* NSTask+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSTask+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSTask+AnyPromise.h"; sourceTree = "<group>"; };
-		069B40FE78D0D96C7AFCFA1737F41470 /* CLSAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLSAttributes.h; path = iOS/Crashlytics.framework/Headers/CLSAttributes.h; sourceTree = "<group>"; };
-		07A9C8F6F2EE664C5C5D021E03EA4A01 /* BigInt-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "BigInt-prefix.pch"; sourceTree = "<group>"; };
-		07B6EF439601A747708F6DD2FF6242F2 /* SipHash-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SipHash-umbrella.h"; sourceTree = "<group>"; };
-		07E8AB5ED7BFCC8954C8B2DD7245033D /* KeystoreV3JSONStructure.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeystoreV3JSONStructure.swift; path = web3swift/KeystoreManager/Classes/KeystoreV3JSONStructure.swift; sourceTree = "<group>"; };
-		07F4E9080671022998131E7FE850380D /* Guarantee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Guarantee.swift; path = Sources/Guarantee.swift; sourceTree = "<group>"; };
-		08ECEE2138B5CD007ED894A9B2302992 /* Promise+Web3+Eth+Call.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+Call.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+Call.swift"; sourceTree = "<group>"; };
-		08FEE5DD01F91DFDFB96333BB631B52F /* CryptoSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.xcconfig; sourceTree = "<group>"; };
-		09A11BABC7FF560066D62BD1E5688FC7 /* Generics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generics.swift; path = Sources/CryptoSwift/Generics.swift; sourceTree = "<group>"; };
-		0A182EFBD4BEB3EB8E3EAFFEBFCB4A07 /* Comparable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Comparable.swift; path = sources/Comparable.swift; sourceTree = "<group>"; };
-		0A29D991D251FA407E8574127CB40CE3 /* Web3+Wallet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Wallet.swift"; path = "web3swift/HookedFunctions/Classes/Web3+Wallet.swift"; sourceTree = "<group>"; };
-		0A5D4088DE323E1E6B0D8585711F435E /* Dictionary+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Extension.swift"; path = "web3swift/Convenience/Classes/Dictionary+Extension.swift"; sourceTree = "<group>"; };
-		0A82428D09BC54E0EE0DA1B4F9A0D20A /* web3swift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = web3swift.xcconfig; sourceTree = "<group>"; };
-		0B9450BA0F46F30E624483F51BD75FC1 /* SwitchCameraButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwitchCameraButton.swift; path = Sources/SwitchCameraButton.swift; sourceTree = "<group>"; };
-		0D870040E819D9A05E8263137AED51C2 /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "web3swift/Convenience/Classes/Array+Extension.swift"; sourceTree = "<group>"; };
-		0D98A342E3C4CE42E7EF1BF9FB8C2E41 /* secp256k1.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1.h; path = secp256k1_ios/include/secp256k1.h; sourceTree = "<group>"; };
-		0DB998FAD907A6E5DFD87374AF7CA9D4 /* Scrypt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Scrypt.swift; path = scrypt/scrypt/Scrypt.swift; sourceTree = "<group>"; };
-		0DE789C6A63202C00A540AAFF2167D75 /* group_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = group_impl.h; path = secp256k1_ios/src/group_impl.h; sourceTree = "<group>"; };
-		0F305D7EB0D67C4E7AA1642D028360C1 /* ecmult_const_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_const_impl.h; path = secp256k1_ios/src/ecmult_const_impl.h; sourceTree = "<group>"; };
-		0FB37EF90329DC22848705FF392DE561 /* Promise+Batching.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Batching.swift"; path = "web3swift/Promises/Classes/Promise+Batching.swift"; sourceTree = "<group>"; };
-		0FD4D52CF24250A1E2C8CDC4EAC746E4 /* CryptoSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CryptoSwift-dummy.m"; sourceTree = "<group>"; };
-		112A6FCDB04E7C609AE8977DC87F23E4 /* PBKDF2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF2.swift; path = Sources/CryptoSwift/PKCS/PBKDF2.swift; sourceTree = "<group>"; };
-		116491EB3DDBCFC5D26AB838F91A61C4 /* BigInt-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "BigInt-dummy.m"; sourceTree = "<group>"; };
-		1259AE93B24BF01BEE804884A4F978C5 /* Promise+Web3+Eth+GetTransactionReceipt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetTransactionReceipt.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetTransactionReceipt.swift"; sourceTree = "<group>"; };
-		14075CA0EEA75B672FB159A8787701FB /* SipHash-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SipHash-dummy.m"; sourceTree = "<group>"; };
-		147B6AEB73C3C9E8513DF4D79021E2D1 /* ABIv2TypeParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2TypeParser.swift; path = web3swift/ABIv2/Classes/ABIv2TypeParser.swift; sourceTree = "<group>"; };
-		15B42CF2FA09282008A2E6844E15042E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1609F2A0E3EB4DB99EABA47647E2DA28 /* Web3+Instance+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Instance+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/Web3+Instance+ObjC.swift"; sourceTree = "<group>"; };
-		166DE5D1E7F051FDD9702B9C7A6474AD /* ContractABIv2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContractABIv2.swift; path = web3swift/Contract/Classes/ContractABIv2.swift; sourceTree = "<group>"; };
-		168447759BCDE275D179C1B1B07182E5 /* Utils+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Utils+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Utils+Foundation.swift"; sourceTree = "<group>"; };
-		16F2514116997A54740C8C2A17DFF32A /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CryptoSwift.framework; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1704372B6C03EF041EA1BFCBABD488C4 /* Authenticator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authenticator.swift; path = Sources/CryptoSwift/Authenticator.swift; sourceTree = "<group>"; };
-		17D01587ACD40F5E9332D90792B4B2A6 /* RandomBytesSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RandomBytesSequence.swift; path = Sources/CryptoSwift/RandomBytesSequence.swift; sourceTree = "<group>"; };
-		17F02B1964D22AE7E6879024A6E2A0F8 /* QRCodeReader.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = QRCodeReader.framework; path = QRCodeReader.swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1816075B02B575B1BE7B00CDBF253774 /* AES.Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.Cryptors.swift; path = Sources/CryptoSwift/AES.Cryptors.swift; sourceTree = "<group>"; };
-		1A02D0753403DB9CE76099B0776D3DC2 /* Promise+Web3+Eth+GetTransactionDetails.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetTransactionDetails.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetTransactionDetails.swift"; sourceTree = "<group>"; };
-		1A8D61BB30BC74B566E0E813078D6D43 /* scratch_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scratch_impl.h; path = secp256k1_ios/src/scratch_impl.h; sourceTree = "<group>"; };
-		1BD0605F39212C4B999DCEC974A04FD8 /* QRCodeReader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReader.swift; path = Sources/QRCodeReader.swift; sourceTree = "<group>"; };
-		1C5E2C13B77294C17BEBCF185D2C71E7 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1CA0C1C52EAA18703E1E942509B0F8E9 /* SecureBytes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecureBytes.swift; path = Sources/CryptoSwift/SecureBytes.swift; sourceTree = "<group>"; };
+		01852DFE34B287694A75EA0A355C3E5D /* Web3+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/Web3+ObjC.swift"; sourceTree = "<group>"; };
+		01CF0F29ECE5A077234420623654BBBB /* Alamofire-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Alamofire-umbrella.h"; sourceTree = "<group>"; };
+		028415A0C2513E40239599F74C61D39D /* IBAN.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IBAN.swift; path = web3swift/KeystoreManager/Classes/IBAN.swift; sourceTree = "<group>"; };
+		03267157904456FAC7624F692E910B55 /* secp256k1_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = secp256k1_ios.framework; path = secp256k1_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		04AE81D5DB9F4D8240587148767BDFF6 /* secp256k1_ecdh.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_ecdh.h; path = secp256k1_ios/include/secp256k1_ecdh.h; sourceTree = "<group>"; };
+		04B551E8C7EDF19BDA8260EDB49E536F /* QRCodeReaderViewControllerBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderViewControllerBuilder.swift; path = Sources/QRCodeReaderViewControllerBuilder.swift; sourceTree = "<group>"; };
+		051DA8488AF7DF4EB56C80335B4E0AAB /* Updatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Updatable.swift; path = Sources/CryptoSwift/Updatable.swift; sourceTree = "<group>"; };
+		0541307DD5375D347F8E968760A8B67E /* fwd.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fwd.h; path = Sources/fwd.h; sourceTree = "<group>"; };
+		056672AFA34A366E30A383A25346F6F6 /* Alamofire.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Alamofire.xcconfig; sourceTree = "<group>"; };
+		05EC65CDE06E17433DBA29F7002C5EDA /* lax_der_privatekey_parsing.c */ = {isa = PBXFileReference; includeInIndex = 1; name = lax_der_privatekey_parsing.c; path = secp256k1_ios/contrib/lax_der_privatekey_parsing.c; sourceTree = "<group>"; };
+		067A6AD52AEA1B0726AFE145CAB24931 /* SipHash-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SipHash-umbrella.h"; sourceTree = "<group>"; };
+		07523400160228A9177C0F89B5A538FF /* Promise+Web3+Personal+UnlockAccount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Personal+UnlockAccount.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Personal+UnlockAccount.swift"; sourceTree = "<group>"; };
+		08B60815E6AF7C1CE2B12FD7EF5E935D /* NoPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoPadding.swift; path = Sources/CryptoSwift/NoPadding.swift; sourceTree = "<group>"; };
+		09530693B905CFC7A6FDC129C4FF9BCC /* BlockExplorer+GetTransactionHistory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BlockExplorer+GetTransactionHistory.swift"; path = "web3swift/BlockExplorer/Classes/BlockExplorer+GetTransactionHistory.swift"; sourceTree = "<group>"; };
+		0A31C3BD52129B6DFCF9A0C8BCEE1781 /* Rabbit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rabbit.swift; path = Sources/CryptoSwift/Rabbit.swift; sourceTree = "<group>"; };
+		0AF2E685B8E27662A8BFA0743A27C5E1 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0B393D9B7755F5DE1F1A4B16B75B34E7 /* Promise+Web3+Contract+GetIndexedEvents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Contract+GetIndexedEvents.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Contract+GetIndexedEvents.swift"; sourceTree = "<group>"; };
+		0BA82B8AB03FC2F59B88A0669833A7ED /* EIP67Code.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EIP67Code.swift; path = web3swift/Utils/Classes/EIP67Code.swift; sourceTree = "<group>"; };
+		0BE47D22AA958D9CD94C0B7B99F0CA68 /* scalar_8x32_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_8x32_impl.h; path = secp256k1_ios/src/scalar_8x32_impl.h; sourceTree = "<group>"; };
+		0C10B9EB6F4E1EDBF4259BA73B1B1345 /* num_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_impl.h; path = secp256k1_ios/src/num_impl.h; sourceTree = "<group>"; };
+		0CE7DE1D82E20261BF472C2DA17A014A /* Checksum.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Checksum.swift; path = Sources/CryptoSwift/Checksum.swift; sourceTree = "<group>"; };
+		0DBED1CDD8405F0862D2D9D5103C0F35 /* web3swift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "web3swift-prefix.pch"; sourceTree = "<group>"; };
+		0E62C76699E81E04C05E307B6A8AF068 /* NSTask+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSTask+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSTask+AnyPromise.m"; sourceTree = "<group>"; };
+		0F000ADE280FAB3A7DF2252A18CCF5ED /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Alamofire.framework; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0F6F2F013DE7F8622027C3569BCF1A9A /* web3swift.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = web3swift.h; path = web3swift/web3swift.h; sourceTree = "<group>"; };
+		101EE83D4F406DE2BC20E6ABE6A438C7 /* scalar_4x64.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_4x64.h; path = secp256k1_ios/src/scalar_4x64.h; sourceTree = "<group>"; };
+		10A0AD3FD6958085628104AAFCB8C3C1 /* UIViewController+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+AnyPromise.m"; path = "Extensions/UIKit/Sources/UIViewController+AnyPromise.m"; sourceTree = "<group>"; };
+		11AC88FC19324B1F65425A48229FA2A9 /* Deprecations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deprecations.swift; path = Sources/Deprecations.swift; sourceTree = "<group>"; };
+		11C97902182015B3601CE10E1F25CE34 /* firstly.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = firstly.swift; path = Sources/firstly.swift; sourceTree = "<group>"; };
+		123708BCF6EF6B6B3CBE29C625D073FE /* AnyPromise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyPromise.swift; path = Sources/AnyPromise.swift; sourceTree = "<group>"; };
+		124CFE84E65BE490249D7B32E18CD4CB /* BigInt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = BigInt.framework; path = BigInt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		12B2ABBEA99EE344B066F54DC7AC1813 /* Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Promise.swift; path = Sources/Promise.swift; sourceTree = "<group>"; };
+		12D685FF90DAA694471CB5BE3721EB71 /* UInt64+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt64+Extension.swift"; path = "Sources/CryptoSwift/UInt64+Extension.swift"; sourceTree = "<group>"; };
+		14FD914ED903081DB2FE4C26E38D3865 /* Data Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data Conversion.swift"; path = "sources/Data Conversion.swift"; sourceTree = "<group>"; };
+		1534BC96A3154081231B949A04C8E579 /* BigInt-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "BigInt-prefix.pch"; sourceTree = "<group>"; };
+		168C58A5F2EE3DA843CAD4C824AA0C52 /* web3swift-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "web3swift-Bridging-Header.h"; path = "web3swift/web3swift-Bridging-Header.h"; sourceTree = "<group>"; };
+		16AA4804DE767546B170499C025D3872 /* Catchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Catchable.swift; path = Sources/Catchable.swift; sourceTree = "<group>"; };
+		17A7144477B01A7D9D160DFD8C0A8C42 /* NameHash.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NameHash.swift; path = web3swift/Utils/Classes/NameHash.swift; sourceTree = "<group>"; };
+		182E59CA843B29EDC922D24FCE451B57 /* RIPEMD160+StackOveflow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "RIPEMD160+StackOveflow.swift"; path = "web3swift/Convenience/Classes/RIPEMD160+StackOveflow.swift"; sourceTree = "<group>"; };
+		19E35848F92A7606931CDF7A787E77B1 /* scrypt.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = scrypt.modulemap; sourceTree = "<group>"; };
+		1A0C29952F599D246626EF905818042D /* Result-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Result-prefix.pch"; sourceTree = "<group>"; };
+		1A5215C0DD24304684C972DFFF7D02FC /* Result.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Result.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1B3FA166F72D9546A2CBA57933AD2886 /* ecmult_gen.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_gen.h; path = secp256k1_ios/src/ecmult_gen.h; sourceTree = "<group>"; };
+		1B979C8BAE317028F54D235D2A0CF1BC /* Cipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cipher.swift; path = Sources/CryptoSwift/Cipher.swift; sourceTree = "<group>"; };
+		1BDBFB5794940426BCD9BC3BEF8C03AB /* Promise+Web3+Intermediate+Send.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Intermediate+Send.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Intermediate+Send.swift"; sourceTree = "<group>"; };
+		1C9AFAD6A9F4E84A058F5A53D7377E0A /* Dictionary+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Extension.swift"; path = "web3swift/Convenience/Classes/Dictionary+Extension.swift"; sourceTree = "<group>"; };
 		1CA91F2BD5FA1BFA7F689AD425A3FABF /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1DD3729C3876B97234310E3E81099B8F /* EIP681.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EIP681.swift; path = web3swift/Utils/Classes/EIP681.swift; sourceTree = "<group>"; };
-		1E4062B2458ED0DE8907C21F000DB3C8 /* Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Fabric.h; path = iOS/Fabric.framework/Headers/Fabric.h; sourceTree = "<group>"; };
-		1E5132DAC664B220CCE54C66915EA32C /* Web3+Options.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Options.swift"; path = "web3swift/Web3/Classes/Web3+Options.swift"; sourceTree = "<group>"; };
-		1F544D2A20CB42C44EBFB2EE25824C5D /* QRCodeReader.swift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "QRCodeReader.swift-umbrella.h"; sourceTree = "<group>"; };
-		1FE6F70BF47E8B23A975E5B8605326AB /* DigestType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DigestType.swift; path = Sources/CryptoSwift/DigestType.swift; sourceTree = "<group>"; };
-		2096C189F0562355E3A36E1297CE4C80 /* Strideable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strideable.swift; path = sources/Strideable.swift; sourceTree = "<group>"; };
-		21557C62840B072F6EEAD19F0D2240B0 /* Thenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Thenable.swift; path = Sources/Thenable.swift; sourceTree = "<group>"; };
-		21796FABFBA40AFBBDD92D9B31F55F52 /* SipHash.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = SipHash.modulemap; sourceTree = "<group>"; };
-		22281779014B1860B15BD0DFAFE85BFC /* ABIv2Elements.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2Elements.swift; path = web3swift/ABIv2/Classes/ABIv2Elements.swift; sourceTree = "<group>"; };
-		22A56A814792F2D067883D1148C235CE /* ecdsa_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdsa_impl.h; path = secp256k1_ios/src/ecdsa_impl.h; sourceTree = "<group>"; };
-		22EE51E952189926295F6C68F96A5523 /* QRCodeReaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderView.swift; path = Sources/QRCodeReaderView.swift; sourceTree = "<group>"; };
-		23E716973755B2E89ADF5EFA78F9A5FB /* BIP32KeystoreJSONStructure.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BIP32KeystoreJSONStructure.swift; path = web3swift/KeystoreManager/Classes/BIP32KeystoreJSONStructure.swift; sourceTree = "<group>"; };
+		1D1C71B00EC0B4FF2154BA22D57B1B84 /* lax_der_privatekey_parsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = lax_der_privatekey_parsing.h; path = secp256k1_ios/contrib/lax_der_privatekey_parsing.h; sourceTree = "<group>"; };
+		1D7BEA031DC24D8856BCB2D0F517DC6E /* OFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OFB.swift; path = Sources/CryptoSwift/BlockMode/OFB.swift; sourceTree = "<group>"; };
+		1F0B56AB8D88FE4DE6C230ACD3C39D54 /* NSRegularExpressionExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSRegularExpressionExtension.swift; path = web3swift/Convenience/Classes/NSRegularExpressionExtension.swift; sourceTree = "<group>"; };
+		1F2DC73E7750E340525D053AAA720356 /* scrypt-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "scrypt-prefix.pch"; sourceTree = "<group>"; };
+		20097552F3A1817336DAA2939737D312 /* scrypt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = scrypt.framework; path = scrypt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		200F222DE33017888FF05655EE1C54CC /* BIP32KeystoreJSONStructure.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BIP32KeystoreJSONStructure.swift; path = web3swift/KeystoreManager/Classes/BIP32KeystoreJSONStructure.swift; sourceTree = "<group>"; };
+		202049474E0CCA0236B0BB25EB3F7428 /* Utils+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Utils+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Utils+Foundation.swift"; sourceTree = "<group>"; };
+		20376F2F2EEE94392F56BFCD0AAA921C /* DigestType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DigestType.swift; path = Sources/CryptoSwift/DigestType.swift; sourceTree = "<group>"; };
+		2081C4B784593A557274AD122C985317 /* BlockCipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockCipher.swift; path = Sources/CryptoSwift/BlockCipher.swift; sourceTree = "<group>"; };
+		20C7E60C088422063704BC0D090F67C9 /* Authenticator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authenticator.swift; path = Sources/CryptoSwift/Authenticator.swift; sourceTree = "<group>"; };
+		228079A457478E0D94A95DD898CE5D74 /* Result.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Result.xcconfig; sourceTree = "<group>"; };
+		229BC0CAF8AD47BBB98F8626C188F13D /* Promise+Web3+Eth+GetBlockByHash.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetBlockByHash.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetBlockByHash.swift"; sourceTree = "<group>"; };
+		2328858BB115D2308FE8B5AFFE824C53 /* race.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = race.m; path = Sources/race.m; sourceTree = "<group>"; };
+		24390439BA0255CEDE98DD9AE1B0C0BE /* TransactionSigner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TransactionSigner.swift; path = web3swift/Transaction/Classes/TransactionSigner.swift; sourceTree = "<group>"; };
+		244B6FF4B1380D326D4C5E6F093CEB7A /* ZeroPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ZeroPadding.swift; path = Sources/CryptoSwift/ZeroPadding.swift; sourceTree = "<group>"; };
+		248F8DA7C2CEF6BE3B419CC9FF46EE91 /* Result-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Result-dummy.m"; sourceTree = "<group>"; };
+		24FDF35724679F9043A665E71C7DE5AD /* web3swift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = web3swift.xcconfig; sourceTree = "<group>"; };
+		256FDD8691B426343D2053D0BE86C4B1 /* ecmult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult.h; path = secp256k1_ios/src/ecmult.h; sourceTree = "<group>"; };
+		25C41C40F3239FB7F59F4EBEB0A3511D /* lax_der_parsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = lax_der_parsing.h; path = secp256k1_ios/contrib/lax_der_parsing.h; sourceTree = "<group>"; };
 		25F4C28C9CCB2EBF237BA397624BF514 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		27337216DDF15B18B0DB1B9B6F8B735C /* NSURLSession+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSURLSession+Promise.swift"; path = "Extensions/Foundation/Sources/NSURLSession+Promise.swift"; sourceTree = "<group>"; };
-		2820F060E279253421A0C56DAA72D99C /* scratch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scratch.h; path = secp256k1_ios/src/scratch.h; sourceTree = "<group>"; };
-		28BD528A7DD471FEC544268CD2A7178C /* Promise+Web3+Eth+SendRawTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+SendRawTransaction.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+SendRawTransaction.swift"; sourceTree = "<group>"; };
-		29B7168224886EC79F36144E6EF63DAA /* scrypt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = scrypt.framework; path = scrypt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2CBF4DD2E9E2CA1D86037728AD0551A2 /* num.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num.h; path = secp256k1_ios/src/num.h; sourceTree = "<group>"; };
-		2D13A6F0B7FD06E7185579216C8C9F45 /* Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Poly1305.swift; path = Sources/CryptoSwift/Poly1305.swift; sourceTree = "<group>"; };
-		2F0620E42997A0C97E03AAE8CC8BCFBD /* firstly.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = firstly.swift; path = Sources/firstly.swift; sourceTree = "<group>"; };
-		2F96370375D8B9AD1B4754DC3CE3C556 /* Web3+Contract.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Contract.swift"; path = "web3swift/Web3/Classes/Web3+Contract.swift"; sourceTree = "<group>"; };
-		2FAD6B3A1AAE9F168F997480BD36871A /* hang.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = hang.swift; path = Sources/hang.swift; sourceTree = "<group>"; };
-		2FE2F408B4FF2738A9F42B10ABC90748 /* AbstractKeystore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AbstractKeystore.swift; path = web3swift/KeystoreManager/Classes/AbstractKeystore.swift; sourceTree = "<group>"; };
-		2FEB134F3E9ADEE9834D6CA22599A7C6 /* Data+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Extension.swift"; path = "web3swift/Convenience/Classes/Data+Extension.swift"; sourceTree = "<group>"; };
-		30556C7671D0B1E8F19FB68CFBF69F91 /* BigUInt+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BigUInt+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/BigUInt+ObjC.swift"; sourceTree = "<group>"; };
-		308BEE6F5CCFBDD8FD9BEBF131AB4E0F /* Promise+Web3+Eth+GetBlockNumber.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetBlockNumber.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetBlockNumber.swift"; sourceTree = "<group>"; };
+		264A299CE22746F7C0CF181C6950609E /* Multiplication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Multiplication.swift; path = sources/Multiplication.swift; sourceTree = "<group>"; };
+		27015053B3711311638314C3A7F0E3A3 /* BIP32Keystore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BIP32Keystore.swift; path = web3swift/KeystoreManager/Classes/BIP32Keystore.swift; sourceTree = "<group>"; };
+		2737110627995C56D4523BEED35D20E7 /* web3swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = web3swift.framework; path = web3swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		27AEAB3F76DC9C5C04CF7CF72FD5C3FC /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		27E5CCF0E45CEB1373D954DBA4B4A322 /* after.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = after.swift; path = Sources/after.swift; sourceTree = "<group>"; };
+		28B0D548D90EED6693E65BFE9FB8FB3F /* ABIv2TypeParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2TypeParser.swift; path = web3swift/ABIv2/Classes/ABIv2TypeParser.swift; sourceTree = "<group>"; };
+		28B3CB87BCF1CA2665B162967F951CA8 /* scrypt.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = scrypt.xcconfig; sourceTree = "<group>"; };
+		2A9E9F05A9B792E0E91D36873C906C0A /* SwitchCameraButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwitchCameraButton.swift; path = Sources/SwitchCameraButton.swift; sourceTree = "<group>"; };
+		2AC6A9765FDB4EADF4B8864803E1690A /* secp256k1_recovery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_recovery.h; path = secp256k1_ios/include/secp256k1_recovery.h; sourceTree = "<group>"; };
+		2B0C4497D7B3C9C961FCE0CFEE1099B8 /* field_5x52.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52.h; path = secp256k1_ios/src/field_5x52.h; sourceTree = "<group>"; };
+		2CA7EC0C1DB8C4EC5D96730BBACB27B1 /* Scrypt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Scrypt.swift; path = scrypt/scrypt/Scrypt.swift; sourceTree = "<group>"; };
+		2CCBD96EC145E10468934052206A64E8 /* Promise+Web3+Eth+GetTransactionReceipt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetTransactionReceipt.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetTransactionReceipt.swift"; sourceTree = "<group>"; };
+		2DD6BB50AD8EF2630AC60A823D4D8B38 /* ResponseSerialization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResponseSerialization.swift; path = Source/ResponseSerialization.swift; sourceTree = "<group>"; };
+		2E642192739CEA390C92AC0356DF0B56 /* Alamofire.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Alamofire.modulemap; sourceTree = "<group>"; };
+		2EF4EC959306B2073A44F94FDD0ABBA9 /* secp256k1_ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = secp256k1_ios.xcconfig; sourceTree = "<group>"; };
+		2F6B987B7208100A40ED658C534AF947 /* Cimpl.c */ = {isa = PBXFileReference; includeInIndex = 1; name = Cimpl.c; path = scrypt/Cimpl.c; sourceTree = "<group>"; };
+		2FDAC5548CA3EB33BFEE567F190504B5 /* scrypt-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "scrypt-dummy.m"; sourceTree = "<group>"; };
+		2FF2E0A2D5E5A09BACB089A01FBF1FB7 /* CLSStackFrame.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLSStackFrame.h; path = iOS/Crashlytics.framework/Headers/CLSStackFrame.h; sourceTree = "<group>"; };
+		30AF75932BDD1310CF0BE737574BB8EB /* PKCS7.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7.swift; path = Sources/CryptoSwift/PKCS/PKCS7.swift; sourceTree = "<group>"; };
 		30F1C78CB74595997600FCDFFECFD859 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		30F9C16F37B00042E1A471CF0F624E33 /* BigInt.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = BigInt.modulemap; sourceTree = "<group>"; };
-		31B00CFBE0F680096E1581F6B59A0F5F /* CompactMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompactMap.swift; path = Sources/CryptoSwift/CompactMap.swift; sourceTree = "<group>"; };
-		3203CE8CEACEE908C8FCE44171BF2FE3 /* join.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = join.m; path = Sources/join.m; sourceTree = "<group>"; };
-		3301B9C2C1C3E440033DF99B705DA5FD /* Data+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Extension.swift"; path = "Sources/CryptoSwift/Foundation/Data+Extension.swift"; sourceTree = "<group>"; };
-		34002D3C3F98CE707F793AD0F71482BD /* BlockModeOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockModeOptions.swift; path = Sources/CryptoSwift/BlockMode/BlockModeOptions.swift; sourceTree = "<group>"; };
-		34F48B3606186F56C547BBAC70FE9E42 /* race.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = race.m; path = Sources/race.m; sourceTree = "<group>"; };
-		35053C5AA7E1933A4C94C0C1AAFBEE9D /* FABAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABAttributes.h; path = iOS/Fabric.framework/Headers/FABAttributes.h; sourceTree = "<group>"; };
-		35CAC501877E70427E127EFA88E10199 /* Catchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Catchable.swift; path = Sources/Catchable.swift; sourceTree = "<group>"; };
-		364EC788A63B85F05F96A9AACE2297AE /* ecmult_gen.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_gen.h; path = secp256k1_ios/src/ecmult_gen.h; sourceTree = "<group>"; };
-		37AD0340E0924A6901378EBD6C1DA73F /* num_gmp.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_gmp.h; path = secp256k1_ios/src/num_gmp.h; sourceTree = "<group>"; };
-		380037FD51C7F639654C9836CAE2E5F3 /* CMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CMAC.swift; path = Sources/CryptoSwift/CMAC.swift; sourceTree = "<group>"; };
-		3860346F961EA6FD2278D645EE921AED /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		38A918E70DCD31FFA1E0D528D6B6DD63 /* PromiseKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PromiseKit.modulemap; sourceTree = "<group>"; };
+		30FD6BFA988D38667768E1C7E6659270 /* num.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num.h; path = secp256k1_ios/src/num.h; sourceTree = "<group>"; };
+		313120D6B0844C95111E1650DE5B68E8 /* CipherModeWorker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CipherModeWorker.swift; path = Sources/CryptoSwift/BlockMode/CipherModeWorker.swift; sourceTree = "<group>"; };
+		314780CA47604CA2ED4B735A4A3EBEBB /* Web3+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Utils.swift"; path = "web3swift/Web3/Classes/Web3+Utils.swift"; sourceTree = "<group>"; };
+		3153BA12BB5A92893507F8F2B04439A0 /* KeystoreManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeystoreManager.swift; path = web3swift/KeystoreManager/Classes/KeystoreManager.swift; sourceTree = "<group>"; };
+		31DC89BD1E950F19A4B697E65EBC702B /* join.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = join.m; path = Sources/join.m; sourceTree = "<group>"; };
+		31F4C8B0EAA83CF8E5F07AFBF5FD6281 /* Web3+HttpProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+HttpProvider.swift"; path = "web3swift/Web3/Classes/Web3+HttpProvider.swift"; sourceTree = "<group>"; };
+		3219EF7CD0C2F08F7F966C59EBD7E201 /* AES.Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.Cryptors.swift; path = Sources/CryptoSwift/AES.Cryptors.swift; sourceTree = "<group>"; };
+		329D2572A9B9E9AB32813C05710EFB65 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Configuration.swift; sourceTree = "<group>"; };
+		341304168E0921272AD3C19EC05F5B5F /* field_10x26_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_10x26_impl.h; path = secp256k1_ios/src/field_10x26_impl.h; sourceTree = "<group>"; };
+		348A903FD4E883A5C775BEDF44449057 /* Result.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Result.swift; path = Result/Result.swift; sourceTree = "<group>"; };
+		3507236898BBAB32C5E17C54301D2439 /* ServerTrustPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServerTrustPolicy.swift; path = Source/ServerTrustPolicy.swift; sourceTree = "<group>"; };
+		353695A952984817097B654FD92DDFCC /* Web3+TransactionIntermediate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+TransactionIntermediate.swift"; path = "web3swift/Web3/Classes/Web3+TransactionIntermediate.swift"; sourceTree = "<group>"; };
+		35A7901737C34A9742D5B99DC7C9466E /* dispatch_promise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = dispatch_promise.m; path = Sources/dispatch_promise.m; sourceTree = "<group>"; };
+		363E36802536D62CF12122E6F649C75D /* web3swift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = web3swift.modulemap; sourceTree = "<group>"; };
+		3826BAA9DEB95CE66CFB35EEF51C5AAB /* QRCodeReader.swift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "QRCodeReader.swift-prefix.pch"; sourceTree = "<group>"; };
+		3860EA4942855E49A62C829717D8ECF4 /* QRCodeReader.swift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "QRCodeReader.swift-umbrella.h"; sourceTree = "<group>"; };
+		38A7C4F04F7073B982C3391CAD512EE2 /* Codable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codable.swift; path = sources/Codable.swift; sourceTree = "<group>"; };
+		39DA4F4135D16F7846D98A5D136594EB /* HMAC+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HMAC+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/HMAC+Foundation.swift"; sourceTree = "<group>"; };
 		39ED000938F638B38685F1C7D5E22786 /* scrypt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = scrypt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		39F845E5734F0004AFE3813BA2D1956C /* HMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HMAC.swift; path = Sources/CryptoSwift/HMAC.swift; sourceTree = "<group>"; };
-		3A0822E6C8EC34132E8689B41A4A9A42 /* Promise+HttpProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+HttpProvider.swift"; path = "web3swift/Promises/Classes/Promise+HttpProvider.swift"; sourceTree = "<group>"; };
-		3A669D344EFFFA9B94F1EA8373BFFC0E /* NSNotificationCenter+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSNotificationCenter+Promise.swift"; path = "Extensions/Foundation/Sources/NSNotificationCenter+Promise.swift"; sourceTree = "<group>"; };
-		3A79EC772E62A13DE0CD7323749B7E37 /* Codable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codable.swift; path = sources/Codable.swift; sourceTree = "<group>"; };
-		3AEED4ACE3931CCC34F30F806D423E05 /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PromiseKit.framework; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3AF492F3A7A03C60C5BF133362B1AF65 /* Web3+ERC20.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+ERC20.swift"; path = "web3swift/PrecompiledContracts/ERC20/Web3+ERC20.swift"; sourceTree = "<group>"; };
-		3B393D0AD2B154707B21DD9E0151F093 /* PlainKeystore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlainKeystore.swift; path = web3swift/KeystoreManager/Classes/PlainKeystore.swift; sourceTree = "<group>"; };
-		3C9463AB3BE7E04AEEBF396C3EEF0B92 /* scrypt.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = scrypt.xcconfig; sourceTree = "<group>"; };
-		3D75797CE630F3A25D64B559810F3930 /* CryptoSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CryptoSwift.modulemap; sourceTree = "<group>"; };
-		3DA6E7C8123A0A5F0EF271F7C109EB9F /* web3swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = web3swift.framework; path = web3swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A3622DDBC1CFFB098930D2CFBBC07C7 /* CryptoSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-prefix.pch"; sourceTree = "<group>"; };
+		3A9E7E3492F16CF045775D93AEF49A94 /* Web3+Methods.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Methods.swift"; path = "web3swift/Web3/Classes/Web3+Methods.swift"; sourceTree = "<group>"; };
+		3C843EBE82ACC990822A3F32C0639EBC /* SessionDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SessionDelegate.swift; path = Source/SessionDelegate.swift; sourceTree = "<group>"; };
+		3CA16A9AE900F8E53C16B7639911CFB8 /* SessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SessionManager.swift; path = Source/SessionManager.swift; sourceTree = "<group>"; };
+		3D040FBD626100B2AD97DA4094AC0FBD /* EthereumAddress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumAddress.swift; path = web3swift/KeystoreManager/Classes/EthereumAddress.swift; sourceTree = "<group>"; };
+		3D296AC4874D9018CD682D9BA4930FE8 /* scratch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scratch.h; path = secp256k1_ios/src/scratch.h; sourceTree = "<group>"; };
+		3D89FB56598E9FDF2253200788961542 /* Addition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Addition.swift; path = sources/Addition.swift; sourceTree = "<group>"; };
+		3DDF980766BE47F9321CB1912ACC7791 /* MultipartFormData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultipartFormData.swift; path = Source/MultipartFormData.swift; sourceTree = "<group>"; };
+		3E856872418F8844D28E0CBEA13BA203 /* field_5x52_int128_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_int128_impl.h; path = secp256k1_ios/src/field_5x52_int128_impl.h; sourceTree = "<group>"; };
 		3EA6A2609AF99A1F3CA14B4A62E043AE /* Result.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3F1A12C496C6650091C82474F2B7E3E9 /* ecmult_gen_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_gen_impl.h; path = secp256k1_ios/src/ecmult_gen_impl.h; sourceTree = "<group>"; };
-		40BB8429BBEE227F1F4E35C982BADDC8 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		423D77A5F4F4FFA5C61FD1B9BC580B44 /* Salsa.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Salsa.swift; path = scrypt/scrypt/Salsa.swift; sourceTree = "<group>"; };
-		423DE1FB7639986D2A99739DD9F77803 /* AEAD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEAD.swift; path = Sources/CryptoSwift/AEAD/AEAD.swift; sourceTree = "<group>"; };
-		42BE142C960BFDE5BCC533A324E49F38 /* AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AnyPromise.h; path = Sources/AnyPromise.h; sourceTree = "<group>"; };
-		4317C6AE4C3DCDDA7D41BD55C5B5FC42 /* secp256k1_ios.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_ios.h; path = secp256k1_ios/secp256k1_ios.h; sourceTree = "<group>"; };
-		432A2035EF1704290FD9017242EDCACB /* Crashlytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Crashlytics.h; path = iOS/Crashlytics.framework/Headers/Crashlytics.h; sourceTree = "<group>"; };
-		4499FB78EF2CA976271E1DD561F132B5 /* Web3+BrowserFunctions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+BrowserFunctions.swift"; path = "web3swift/HookedFunctions/Classes/Web3+BrowserFunctions.swift"; sourceTree = "<group>"; };
-		454398613D40E174051C0EC0F05B4B27 /* Shifts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Shifts.swift; path = sources/Shifts.swift; sourceTree = "<group>"; };
-		45C2948CBB2860088420738DCCAFEA2F /* NoPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoPadding.swift; path = Sources/CryptoSwift/NoPadding.swift; sourceTree = "<group>"; };
-		467FBA75EB54C769E993036F93727FE5 /* afterlife.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = afterlife.swift; path = Extensions/Foundation/Sources/afterlife.swift; sourceTree = "<group>"; };
-		46F9736F1CED5682322FB9397E8715D9 /* Answers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Answers.h; path = iOS/Crashlytics.framework/Headers/Answers.h; sourceTree = "<group>"; };
-		47D1682813F759C273A31C2B4B5C5A95 /* Web3+Eth+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Eth+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/Web3+Eth+ObjC.swift"; sourceTree = "<group>"; };
-		492E47E3E5D3546B33A83112EE9EEFBF /* SipHash-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SipHash-prefix.pch"; sourceTree = "<group>"; };
-		493CB8292859030078340B11BFF6B29F /* BlockEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockEncryptor.swift; path = Sources/CryptoSwift/BlockEncryptor.swift; sourceTree = "<group>"; };
-		495C0ADF7FE8768DC36EE0D4CCF706BB /* SHA2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA2.swift; path = Sources/CryptoSwift/SHA2.swift; sourceTree = "<group>"; };
-		49891B8F292E9704D7BDC4E521EB5B88 /* scalar_low.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_low.h; path = secp256k1_ios/src/scalar_low.h; sourceTree = "<group>"; };
-		4A2D8F7A44C9A04DE2232E3D77A120B8 /* BIP32HDNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BIP32HDNode.swift; path = web3swift/KeystoreManager/Classes/BIP32HDNode.swift; sourceTree = "<group>"; };
-		4B160E67829EADD2CCD679C0D5CD6E82 /* main_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = main_impl.h; path = secp256k1_ios/src/modules/ecdh/main_impl.h; sourceTree = "<group>"; };
-		4B6DE265854D1861093D783AC9356B49 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "Sources/CryptoSwift/String+Extension.swift"; sourceTree = "<group>"; };
-		4C0E4445536E7E006B2D0CBE3BA980AF /* Exponentiation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Exponentiation.swift; path = sources/Exponentiation.swift; sourceTree = "<group>"; };
-		4CAA5E70273C0F733622CF994C04E8D9 /* Blowfish.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Blowfish.swift; path = Sources/CryptoSwift/Blowfish.swift; sourceTree = "<group>"; };
-		4DA7456076875720004B445B49676E91 /* CryptoExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CryptoExtensions.swift; path = web3swift/Convenience/Classes/CryptoExtensions.swift; sourceTree = "<group>"; };
-		4E5D58CDD8D4E7674C84DF5A317C398D /* BlockCipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockCipher.swift; path = Sources/CryptoSwift/BlockCipher.swift; sourceTree = "<group>"; };
-		4F3B07290B1E3D40DD19152E4D8B12BC /* scrypt.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = scrypt.modulemap; sourceTree = "<group>"; };
-		4F58337C98259FDA10B250EDFD6CDBB7 /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fabric.framework; path = iOS/Fabric.framework; sourceTree = "<group>"; };
-		4F77F20EAEAABCAC2FA77A90BC1F5DF6 /* Subtraction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Subtraction.swift; path = sources/Subtraction.swift; sourceTree = "<group>"; };
-		50AAD3B6CB72AF6FBAAC9050B0812F9F /* scrypt-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "scrypt-prefix.pch"; sourceTree = "<group>"; };
-		52242637417D88569D291E75739F18F0 /* PromiseKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PromiseKit.h; path = Sources/PromiseKit.h; sourceTree = "<group>"; };
-		52974B5C907F23B4873E61DEBD141134 /* BlockExplorer+GetTransactionHistory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BlockExplorer+GetTransactionHistory.swift"; path = "web3swift/BlockExplorer/Classes/BlockExplorer+GetTransactionHistory.swift"; sourceTree = "<group>"; };
-		52AAE0A2C0DDE48ACF55A256D9FF27DA /* field_5x52.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52.h; path = secp256k1_ios/src/field_5x52.h; sourceTree = "<group>"; };
+		3F41DA8948731CD42489BE7B783574EF /* BIP39+WordLists.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BIP39+WordLists.swift"; path = "web3swift/KeystoreManager/Classes/BIP39+WordLists.swift"; sourceTree = "<group>"; };
+		400974DD0BAFA502C534CED0FDF36E4F /* CBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBC.swift; path = Sources/CryptoSwift/BlockMode/CBC.swift; sourceTree = "<group>"; };
+		4036E3F8719C9DA138447CF896990DF0 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CryptoSwift.framework; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		40D9F663926E8B062E03E5DEE5432224 /* ChaCha20+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ChaCha20+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/ChaCha20+Foundation.swift"; sourceTree = "<group>"; };
+		41102EF377C8CDAC35545F9584C7C182 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "web3swift/Convenience/Classes/String+Extension.swift"; sourceTree = "<group>"; };
+		41366DDC06EA73CDFBD8E1CA9C774F03 /* KeystoreManager+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "KeystoreManager+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/KeystoreManager+ObjC.swift"; sourceTree = "<group>"; };
+		418047EC2D5B05083EEFC267F36DFF2F /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "web3swift/Convenience/Classes/Array+Extension.swift"; sourceTree = "<group>"; };
+		41AEA2DF1157620919DECEC2873190EE /* LibSecp256k1Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LibSecp256k1Extension.swift; path = web3swift/Convenience/Classes/LibSecp256k1Extension.swift; sourceTree = "<group>"; };
+		426DF9C25A724BDBA5332E8E568A989D /* CryptoSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.xcconfig; sourceTree = "<group>"; };
+		42F13C96ED45C95FC41551CDE5A6D68F /* Words and Bits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Words and Bits.swift"; path = "sources/Words and Bits.swift"; sourceTree = "<group>"; };
+		431DAA8C35760A30EAD4D2C1E41D8C1C /* Result.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Result.modulemap; sourceTree = "<group>"; };
+		43C1B47B887904819BBE309C8F894E28 /* BIP32HDNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BIP32HDNode.swift; path = web3swift/KeystoreManager/Classes/BIP32HDNode.swift; sourceTree = "<group>"; };
+		4510A3501569C7B4E5F4871FD8A5C827 /* NSNotificationCenter+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.h"; sourceTree = "<group>"; };
+		455F2819B3A0EA97496C5877D0E29378 /* Web3+JSONRPC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+JSONRPC.swift"; path = "web3swift/Web3/Classes/Web3+JSONRPC.swift"; sourceTree = "<group>"; };
+		45748A876870FC089152EF8FD81E9A75 /* RLP.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RLP.swift; path = web3swift/Utils/Classes/RLP.swift; sourceTree = "<group>"; };
+		4589A3D54AFD2251264C4910E695872B /* Blowfish.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Blowfish.swift; path = Sources/CryptoSwift/Blowfish.swift; sourceTree = "<group>"; };
+		4647F04C7ED31642A5C97FFEB14C4FD0 /* BigInt-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "BigInt-umbrella.h"; sourceTree = "<group>"; };
+		466E434A39BBD238A4D05E63F2A34E4E /* ChaCha20.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChaCha20.swift; path = Sources/CryptoSwift/ChaCha20.swift; sourceTree = "<group>"; };
+		467F795F6A9C3E0DFDD0FE46DFDC5186 /* AEAD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEAD.swift; path = Sources/CryptoSwift/AEAD/AEAD.swift; sourceTree = "<group>"; };
+		469AA552618E9C216A633389DEC44B18 /* BigInt.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = BigInt.xcconfig; sourceTree = "<group>"; };
+		46FBB4349EC969ED97E0E4CE07FA1333 /* ecmult_const.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_const.h; path = secp256k1_ios/src/ecmult_const.h; sourceTree = "<group>"; };
+		471B3967D8491DAB0642DC353C096A6D /* SHA2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA2.swift; path = Sources/CryptoSwift/SHA2.swift; sourceTree = "<group>"; };
+		4745C274EF8239883C005C2A06EA7255 /* eckey.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = eckey.h; path = secp256k1_ios/src/eckey.h; sourceTree = "<group>"; };
+		477123AC338560B8480BAF4EB5D7988E /* ABIv2Parsing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2Parsing.swift; path = web3swift/ABIv2/Classes/ABIv2Parsing.swift; sourceTree = "<group>"; };
+		48767CE0F05CCE5D2C8AF7EFB32549FF /* FABAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABAttributes.h; path = iOS/Fabric.framework/Headers/FABAttributes.h; sourceTree = "<group>"; };
+		4996D8E35AB40C6394A8C8149844B437 /* QRCodeReaderViewControllerDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderViewControllerDelegate.swift; path = Sources/QRCodeReaderViewControllerDelegate.swift; sourceTree = "<group>"; };
+		49FF436EC9B609E571B4778D2AF17F45 /* Web3+HttpProvider+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+HttpProvider+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/Web3+HttpProvider+ObjC.swift"; sourceTree = "<group>"; };
+		4AD300E1DE0EC70FDA3B58AFBF0BDB0D /* ABIv2Elements.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2Elements.swift; path = web3swift/ABIv2/Classes/ABIv2Elements.swift; sourceTree = "<group>"; };
+		4B5D61860F5FD79DD8123BCB7ECA75EB /* HMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HMAC.swift; path = Sources/CryptoSwift/HMAC.swift; sourceTree = "<group>"; };
+		4BF6CEF45BF5ADAC2C2EE5B3F4563116 /* BloomFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BloomFilter.swift; path = web3swift/Transaction/Classes/BloomFilter.swift; sourceTree = "<group>"; };
+		4E2FFE6E982290CFF29A826A4B438822 /* PromiseKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PromiseKit.h; path = Sources/PromiseKit.h; sourceTree = "<group>"; };
+		502435EEEA3CAA6A5A83F0BB7EE5EBA9 /* PMKUIKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PMKUIKit.h; path = Extensions/UIKit/Sources/PMKUIKit.h; sourceTree = "<group>"; };
+		5098F30FAB47D07396CBB0BE1DFED618 /* Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Random.swift; path = sources/Random.swift; sourceTree = "<group>"; };
+		50FA1AD549AF9033EB1C6ECC3198AAD8 /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Request.swift; path = Source/Request.swift; sourceTree = "<group>"; };
+		5204B9F811E9F85B65EACB4BCE2A0E40 /* EthereumTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumTransaction.swift; path = web3swift/Transaction/Classes/EthereumTransaction.swift; sourceTree = "<group>"; };
+		5206A86DDC8B1123CCC4220921B4ED0F /* Crashlytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Crashlytics.h; path = iOS/Crashlytics.framework/Headers/Crashlytics.h; sourceTree = "<group>"; };
+		5229EE3657A2EDF787D3C3D30FF03335 /* Int+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Int+Extension.swift"; path = "Sources/CryptoSwift/Int+Extension.swift"; sourceTree = "<group>"; };
+		52756545CBB2AEE411B9EAC53FEE5CCB /* NoError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoError.swift; path = Result/NoError.swift; sourceTree = "<group>"; };
 		52EA56A9EF83E4CC6F7B02F5D1878DB7 /* Pods-DiveLane-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-DiveLane-umbrella.h"; sourceTree = "<group>"; };
-		5315E4C0E16806FBD1FEE84852B9A530 /* field.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field.h; path = secp256k1_ios/src/field.h; sourceTree = "<group>"; };
-		53C2D41F3888015B5D33A898FD0BDBA2 /* hang.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = hang.m; path = Sources/hang.m; sourceTree = "<group>"; };
-		53DBFB7B72D0AEA4C3DFC83B0D922333 /* dispatch_promise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = dispatch_promise.m; path = Sources/dispatch_promise.m; sourceTree = "<group>"; };
-		53F39FA42D6BF866A8B4E3829C876592 /* secp256k1_ios-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "secp256k1_ios-prefix.pch"; sourceTree = "<group>"; };
-		54D1A77434D0B4FEE3D3DE61CF971BAA /* ChaCha20.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChaCha20.swift; path = Sources/CryptoSwift/ChaCha20.swift; sourceTree = "<group>"; };
-		5552C4D8C9464EDF1E94F0B4FA62ECA5 /* UInt128.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UInt128.swift; path = Sources/CryptoSwift/UInt128.swift; sourceTree = "<group>"; };
-		56E2F4ABFD2C598332B26D0985CCDF9A /* Square Root.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Square Root.swift"; path = "sources/Square Root.swift"; sourceTree = "<group>"; };
-		58152D6BC0953D378603360B64894468 /* BIP39+WordLists.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BIP39+WordLists.swift"; path = "web3swift/KeystoreManager/Classes/BIP39+WordLists.swift"; sourceTree = "<group>"; };
-		58ABCCBE5A99415F6F404C6824E5CCE6 /* CryptoSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-prefix.pch"; sourceTree = "<group>"; };
-		5A8DDB6D2B5E479727139DEE5E29C989 /* after.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = after.m; path = Sources/after.m; sourceTree = "<group>"; };
-		5ABEFEDF0B2C2DAE50EE05965F4F2763 /* field_5x52_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_impl.h; path = secp256k1_ios/src/field_5x52_impl.h; sourceTree = "<group>"; };
-		5B603A3DF5A832302D45AA5314EE8179 /* Promise+Web3+Intermediate+Send.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Intermediate+Send.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Intermediate+Send.swift"; sourceTree = "<group>"; };
-		5BCE86301701700B88CD7D4A5D2F8AD8 /* scalar_8x32_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_8x32_impl.h; path = secp256k1_ios/src/scalar_8x32_impl.h; sourceTree = "<group>"; };
-		5C9AAD1576095621D68E0542F640A916 /* secp256k1_ios-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "secp256k1_ios-umbrella.h"; sourceTree = "<group>"; };
-		5CEDBC5518CC046F3FAF974A34A632F6 /* group.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = group.h; path = secp256k1_ios/src/group.h; sourceTree = "<group>"; };
-		5D2F80B6633B1B0FC06182C5EEBFF4CC /* Box.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Box.swift; path = Sources/Box.swift; sourceTree = "<group>"; };
-		5DD25864EC42F1D4A3ABE45779307FB0 /* PKCS7.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7.swift; path = Sources/CryptoSwift/PKCS/PKCS7.swift; sourceTree = "<group>"; };
-		5EAAFE7F970149EEB716AF8A63B196BE /* BloomFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BloomFilter.swift; path = web3swift/Transaction/Classes/BloomFilter.swift; sourceTree = "<group>"; };
-		5F0F9A14D8E737876058FD244DCF8451 /* ENS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ENS.swift; path = web3swift/Utils/Classes/ENS.swift; sourceTree = "<group>"; };
-		5F1C9082978CBBE222D623A50BA9029B /* ABIv2Encoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2Encoding.swift; path = web3swift/ABIv2/Classes/ABIv2Encoding.swift; sourceTree = "<group>"; };
-		601B089A77FC1BDA7B65D8B49C417791 /* secp256k1_ecdh.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_ecdh.h; path = secp256k1_ios/include/secp256k1_ecdh.h; sourceTree = "<group>"; };
-		604E46FD931FB989638FAD6E513EE901 /* NSURLSession+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLSession+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSURLSession+AnyPromise.h"; sourceTree = "<group>"; };
+		53462C3C917ABB5047BB31683E29A3C5 /* Promise+Web3+Eth+GetBalance.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetBalance.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetBalance.swift"; sourceTree = "<group>"; };
+		55D9A86A09328B52065F37F62B0DA725 /* BigUInt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BigUInt.swift; path = sources/BigUInt.swift; sourceTree = "<group>"; };
+		564EACCD48CFBD4ED24477096788B35F /* CFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CFB.swift; path = Sources/CryptoSwift/BlockMode/CFB.swift; sourceTree = "<group>"; };
+		56F399204F0B76DF92B22D4221126C0B /* web3swift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "web3swift-dummy.m"; sourceTree = "<group>"; };
+		5705E17A5DC8CD041A2FCB5A82346147 /* AnyError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyError.swift; path = Result/AnyError.swift; sourceTree = "<group>"; };
+		58C2E683987F15936DEBBB1187F7DB51 /* Result.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Result.swift; path = Source/Result.swift; sourceTree = "<group>"; };
+		5956074886CED0A604FBDCD722BA8887 /* PromiseKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-prefix.pch"; sourceTree = "<group>"; };
+		5AF3EA57EE4D3FFB37E2559DBF18CC6C /* Pods_DiveLane.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_DiveLane.framework; path = "Pods-DiveLane.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BE1814071187E6505D8CCDF37C0FBD7 /* Promise+Web3+Eth+GetTransactionDetails.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetTransactionDetails.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetTransactionDetails.swift"; sourceTree = "<group>"; };
+		5C2BB327C9C1AAFC7DE617C91C6D1CDA /* BIP39.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BIP39.swift; path = web3swift/KeystoreManager/Classes/BIP39.swift; sourceTree = "<group>"; };
+		5C54B58C29DFD97FBC7100505A8C2600 /* CompactMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompactMap.swift; path = Sources/CryptoSwift/CompactMap.swift; sourceTree = "<group>"; };
+		5CC0D7B391633DBB114E1F27A93BA165 /* Promise+Web3+Eth+GetGasPrice.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetGasPrice.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetGasPrice.swift"; sourceTree = "<group>"; };
+		5CC8D1E73F3D420CD00739B71C0703B8 /* TaskDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TaskDelegate.swift; path = Source/TaskDelegate.swift; sourceTree = "<group>"; };
+		5DA9457B5C2C61A5998AB2070FDE20B0 /* scalar_low.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_low.h; path = secp256k1_ios/src/scalar_low.h; sourceTree = "<group>"; };
+		5E53A5B5BC58ADF41631607A5FD30732 /* Cryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptor.swift; path = Sources/CryptoSwift/Cryptor.swift; sourceTree = "<group>"; };
+		5E669092646301ACE55600867B2D4DA6 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Crashlytics.framework; path = iOS/Crashlytics.framework; sourceTree = "<group>"; };
+		5E686AD219F4FAF8FD26B1978591799E /* secp256k1_ios-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "secp256k1_ios-prefix.pch"; sourceTree = "<group>"; };
+		5E8BD85FC52AE77C7EDC80C09626560E /* PromiseKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PromiseKit.modulemap; sourceTree = "<group>"; };
+		5EF031BCCC36CFE433CDA5CE06B9E32F /* Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Fabric.h; path = iOS/Fabric.framework/Headers/Fabric.h; sourceTree = "<group>"; };
+		5F6AE0B6578FC38928FDAE2A1D7F1950 /* QRCodeReader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReader.swift; path = Sources/QRCodeReader.swift; sourceTree = "<group>"; };
+		5FE7D0E9CCED9C9CE1FBEE4A5253E1F2 /* after.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = after.m; path = Sources/after.m; sourceTree = "<group>"; };
+		6017DE25135638C3828C30F112AB8975 /* Data+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Extension.swift"; path = "web3swift/Convenience/Classes/Data+Extension.swift"; sourceTree = "<group>"; };
 		60752C72B20ED22FD8D88C7502A2EDEF /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/AVFoundation.framework; sourceTree = DEVELOPER_DIR; };
-		608A1FDD759AE0938FDE3DC293A06A34 /* Blowfish+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Blowfish+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Blowfish+Foundation.swift"; sourceTree = "<group>"; };
-		6111B1E010967857A74EF10904989919 /* Result.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Result.swift; path = Result/Result.swift; sourceTree = "<group>"; };
-		6138927DBD256234EEF7A0607055F4A5 /* BigInt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = BigInt.framework; path = BigInt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		61D095D938B024427A74E17FEFDC681E /* Web3+Protocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Protocols.swift"; path = "web3swift/Web3/Classes/Web3+Protocols.swift"; sourceTree = "<group>"; };
-		627075D1CD3CC2CD9BAC5F5A59164588 /* UIView+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIView+Promise.swift"; path = "Extensions/UIKit/Sources/UIView+Promise.swift"; sourceTree = "<group>"; };
-		62BAFC302544761C154C3C312785A956 /* Web3+Infura.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Infura.swift"; path = "web3swift/Web3/Classes/Web3+Infura.swift"; sourceTree = "<group>"; };
-		62BE12C598888D291FFB815FB310D2FD /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Crashlytics.framework; path = iOS/Crashlytics.framework; sourceTree = "<group>"; };
-		6324C43D4F9B2EC0C44B602C73FA7999 /* CFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CFB.swift; path = Sources/CryptoSwift/BlockMode/CFB.swift; sourceTree = "<group>"; };
-		637AA645BCF8A061118CCDB1207C8A69 /* secp256k1_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = secp256k1_ios.framework; path = secp256k1_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		638651C3710123A24F0E3D5389F38244 /* UInt8+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt8+Extension.swift"; path = "Sources/CryptoSwift/UInt8+Extension.swift"; sourceTree = "<group>"; };
-		644FF28E462665CF8CCAD2B89260E2AB /* ecmult_const.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_const.h; path = secp256k1_ios/src/ecmult_const.h; sourceTree = "<group>"; };
-		6522C7D53C4ED1BCB2C616D342D0C211 /* Web3+EventParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+EventParser.swift"; path = "web3swift/Web3/Classes/Web3+EventParser.swift"; sourceTree = "<group>"; };
-		6545781899C7A95A8BD49CD63992D424 /* scalar_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_impl.h; path = secp256k1_ios/src/scalar_impl.h; sourceTree = "<group>"; };
-		6550B0F982A3AFAE39A3901DF284CFE4 /* lax_der_parsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = lax_der_parsing.h; path = secp256k1_ios/contrib/lax_der_parsing.h; sourceTree = "<group>"; };
-		65D5BB8EAB2F4FB5B4DCEAF94C6EB713 /* Promise+Web3+Personal+UnlockAccount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Personal+UnlockAccount.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Personal+UnlockAccount.swift"; sourceTree = "<group>"; };
+		614F03A94B3CA7BCFE7AD4B98555030F /* UInt32+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt32+Extension.swift"; path = "Sources/CryptoSwift/UInt32+Extension.swift"; sourceTree = "<group>"; };
+		63CA4DD74FB0F34DA9088C2DD00A6C7D /* UIViewController+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+AnyPromise.h"; path = "Extensions/UIKit/Sources/UIViewController+AnyPromise.h"; sourceTree = "<group>"; };
+		6416379E455C5139431635058364658B /* PCBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PCBC.swift; path = Sources/CryptoSwift/BlockMode/PCBC.swift; sourceTree = "<group>"; };
 		664AEC560E1890D2ACDBD5C818D02E07 /* Pods-DiveLane-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-DiveLane-dummy.m"; sourceTree = "<group>"; };
-		667F734F7FA99E745C2835EC2DA2C4BF /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "Sources/CryptoSwift/Array+Extension.swift"; sourceTree = "<group>"; };
-		66912792AB23217C495C7D419F13EE63 /* AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AnyPromise.m; path = Sources/AnyPromise.m; sourceTree = "<group>"; };
-		67D0F512593FCE3F829AA0A99A087829 /* fwd.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fwd.h; path = Sources/fwd.h; sourceTree = "<group>"; };
-		68B4BB25775036EC78B3BF4A5BE8FE39 /* Rabbit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rabbit.swift; path = Sources/CryptoSwift/Rabbit.swift; sourceTree = "<group>"; };
-		69520391266ED84E73AEEE018929DA2F /* scalar_8x32.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_8x32.h; path = secp256k1_ios/src/scalar_8x32.h; sourceTree = "<group>"; };
-		695E0D04AB9B729454BADA86F2F4997E /* QRCodeReader.swift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = QRCodeReader.swift.modulemap; sourceTree = "<group>"; };
-		6A80FA1CCA53746C9DA607B2D8DEBD36 /* Web3+Methods.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Methods.swift"; path = "web3swift/Web3/Classes/Web3+Methods.swift"; sourceTree = "<group>"; };
-		6AAB871FAB1037C110E267D4796ECF8B /* LibSecp256k1Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LibSecp256k1Extension.swift; path = web3swift/Convenience/Classes/LibSecp256k1Extension.swift; sourceTree = "<group>"; };
-		6CC5946A47DB0731B068118DF7AD545B /* secp256k1_recovery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_recovery.h; path = secp256k1_ios/include/secp256k1_recovery.h; sourceTree = "<group>"; };
-		6CF0A2349580453266D55F969B32F05B /* RandomUInt64.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RandomUInt64.swift; path = SipHash/RandomUInt64.swift; sourceTree = "<group>"; };
-		6DA62EB56D9502B656E1ED4F5FA1309E /* QRCodeReaderViewControllerDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderViewControllerDelegate.swift; path = Sources/QRCodeReaderViewControllerDelegate.swift; sourceTree = "<group>"; };
-		6E92704F9468A8DC78B75C3F8C46F61F /* BIP32Keystore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BIP32Keystore.swift; path = web3swift/KeystoreManager/Classes/BIP32Keystore.swift; sourceTree = "<group>"; };
+		68C20F6218D2D54CC76539F69C082B4E /* EthereumKeystoreV3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumKeystoreV3.swift; path = web3swift/KeystoreManager/Classes/EthereumKeystoreV3.swift; sourceTree = "<group>"; };
+		68D9FB9D5B9D0CDF0571383B95ABC1E4 /* SipHash-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SipHash-dummy.m"; sourceTree = "<group>"; };
+		693BFC0D19556FFCE33111EA56CCAC03 /* BigInt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BigInt.swift; path = sources/BigInt.swift; sourceTree = "<group>"; };
+		69A8581A98F919BDD990E2151B4CD5DA /* ABIv2Decoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2Decoding.swift; path = web3swift/ABIv2/Classes/ABIv2Decoding.swift; sourceTree = "<group>"; };
+		6A302CC286398A108E7231D64743135C /* CryptoExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CryptoExtensions.swift; path = web3swift/Convenience/Classes/CryptoExtensions.swift; sourceTree = "<group>"; };
+		6AC95AC35C6E78B9879CAFF04EEB9578 /* BatchedCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BatchedCollection.swift; path = Sources/CryptoSwift/BatchedCollection.swift; sourceTree = "<group>"; };
+		6B623A2B8697B4678F96B21A6B722FC6 /* EthereumAddress+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "EthereumAddress+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/EthereumAddress+ObjC.swift"; sourceTree = "<group>"; };
+		6BBF9DAE2BE96268A66EC11337DE66CE /* scalar.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar.h; path = secp256k1_ios/src/scalar.h; sourceTree = "<group>"; };
+		6C27A154651D4F380BA194E9F6FE8C89 /* UInt128.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UInt128.swift; path = Sources/CryptoSwift/UInt128.swift; sourceTree = "<group>"; };
+		6C4AEDF255D6A629E1A280179E5A7A5A /* SipHasher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SipHasher.swift; path = SipHash/SipHasher.swift; sourceTree = "<group>"; };
+		6D8E7890E553410A109389CB2B47FAFB /* ABIv2Encoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2Encoding.swift; path = web3swift/ABIv2/Classes/ABIv2Encoding.swift; sourceTree = "<group>"; };
+		6E135D280E58286565605E0EE6CBA253 /* Promise+Web3+Eth+GetTransactionCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetTransactionCount.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetTransactionCount.swift"; sourceTree = "<group>"; };
+		6E442F38E92C044663A7567FEC0218DB /* afterlife.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = afterlife.swift; path = Extensions/Foundation/Sources/afterlife.swift; sourceTree = "<group>"; };
+		6E5F4741DEF41B9DE628EEF93D72CB87 /* Promise+Web3+Eth+EstimateGas.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+EstimateGas.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+EstimateGas.swift"; sourceTree = "<group>"; };
+		6EC6C34F1EB41D1A5C278D510066904B /* Web3+BrowserFunctions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+BrowserFunctions.swift"; path = "web3swift/HookedFunctions/Classes/Web3+BrowserFunctions.swift"; sourceTree = "<group>"; };
+		6EE955DAE69C8E70BC0EFC70000E07FC /* ContractProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContractProtocol.swift; path = web3swift/Contract/Classes/ContractProtocol.swift; sourceTree = "<group>"; };
 		6F4EA344939811A4346AE226D6D7490D /* BigInt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BigInt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6F57ECA9E5BBCCC7BCCCEBC506FE75A8 /* Primitive Types.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Primitive Types.swift"; path = "SipHash/Primitive Types.swift"; sourceTree = "<group>"; };
-		6F63C1B9F2BDF4747B7CBE35E7A0563A /* Cimpl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Cimpl.h; path = scrypt/Cimpl.h; sourceTree = "<group>"; };
-		6F7E1C14BBBF779E4B6B5F784AFCFAD7 /* GCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GCM.swift; path = Sources/CryptoSwift/BlockMode/GCM.swift; sourceTree = "<group>"; };
+		6FDDD749C3760952A98C4202E2CD7F99 /* ecdsa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdsa.h; path = secp256k1_ios/src/ecdsa.h; sourceTree = "<group>"; };
+		7041BC27C28AD00A274104896D8943E3 /* CryptoSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CryptoSwift-dummy.m"; sourceTree = "<group>"; };
+		706B73F36D2AA0D1FFC213721F48B3A4 /* ENS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ENS.swift; path = web3swift/Utils/Classes/ENS.swift; sourceTree = "<group>"; };
 		706D8E9400AC9ABEDFDCA0E98284A99F /* SipHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SipHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		70BA52C5917E5A43E50F5CFFA8520DCA /* ABIv2Decoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2Decoding.swift; path = web3swift/ABIv2/Classes/ABIv2Decoding.swift; sourceTree = "<group>"; };
-		714A2D37F8F87E883F046D7828AB6D98 /* SipHasher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SipHasher.swift; path = SipHash/SipHasher.swift; sourceTree = "<group>"; };
-		714DAAE8E7D5ACDCCA832E4C597E499D /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Configuration.swift; sourceTree = "<group>"; };
-		71B75973741B8C0A92BDD1A39BF6176B /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/Error.swift; sourceTree = "<group>"; };
-		721ED87D8D0B64B0CFE26E691A3626E1 /* Result-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Result-umbrella.h"; sourceTree = "<group>"; };
-		72BC742DB402AF7B08A06EE403E81E34 /* Division.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Division.swift; path = sources/Division.swift; sourceTree = "<group>"; };
-		732314F22D2BE49B430C8F340F5E8B86 /* AEADChaCha20Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEADChaCha20Poly1305.swift; path = Sources/CryptoSwift/AEAD/AEADChaCha20Poly1305.swift; sourceTree = "<group>"; };
-		741946BB436E10C32D32D95AA6E2C46E /* PromiseKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PromiseKit-dummy.m"; sourceTree = "<group>"; };
-		7480746568231EDF17603715FE554263 /* BigInt-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "BigInt-umbrella.h"; sourceTree = "<group>"; };
-		74C4F7726797CD7DABAEB28367A6E6CD /* web3swift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "web3swift-dummy.m"; sourceTree = "<group>"; };
-		75D2B4F401F83AED97758430F7961B31 /* Floating Point Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Floating Point Conversion.swift"; path = "sources/Floating Point Conversion.swift"; sourceTree = "<group>"; };
-		75E649687609BA0B77003F631ACCAF69 /* PromiseKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-umbrella.h"; sourceTree = "<group>"; };
-		760710F8F0DCFBEE321D645FC9EC8799 /* EthereumFilterEncodingExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumFilterEncodingExtensions.swift; path = web3swift/Contract/Classes/EthereumFilterEncodingExtensions.swift; sourceTree = "<group>"; };
-		767567F023FAC512B3AA4051D088CE0B /* web3swift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = web3swift.modulemap; sourceTree = "<group>"; };
-		76D19F9EAEF25529BF3F3B331F292817 /* AnyPromise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyPromise.swift; path = Sources/AnyPromise.swift; sourceTree = "<group>"; };
-		781D6EBD207326333AF47A6E96B0513D /* secp256k1_ios-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "secp256k1_ios-dummy.m"; sourceTree = "<group>"; };
-		793EAE17ACE0F873D75CC2FAF1AB96D7 /* when.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = when.swift; path = Sources/when.swift; sourceTree = "<group>"; };
-		7A06551A72C20599D9C7A45956FDBD26 /* hash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash.h; path = secp256k1_ios/src/hash.h; sourceTree = "<group>"; };
-		7A737611902B285FF9F052CF2E61EFF8 /* Web3+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/Web3+ObjC.swift"; sourceTree = "<group>"; };
-		7AC98C526C6420EA0CA8A80773A9D5CD /* scalar_low_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_low_impl.h; path = secp256k1_ios/src/scalar_low_impl.h; sourceTree = "<group>"; };
-		7ACA44517F51EA28DB0C302D2051C522 /* NSRegularExpressionExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSRegularExpressionExtension.swift; path = web3swift/Convenience/Classes/NSRegularExpressionExtension.swift; sourceTree = "<group>"; };
-		7BFEF37D5BF463C9959B0164D3C71435 /* UIViewPropertyAnimator+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIViewPropertyAnimator+Promise.swift"; path = "Extensions/UIKit/Sources/UIViewPropertyAnimator+Promise.swift"; sourceTree = "<group>"; };
-		7C267C22945AF26C33C325CE17070F06 /* field_5x52_int128_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_int128_impl.h; path = secp256k1_ios/src/field_5x52_int128_impl.h; sourceTree = "<group>"; };
-		7C890F5D6BDE1F66CCC42BCA89FC70C9 /* Base58.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Base58.swift; path = web3swift/Convenience/Classes/Base58.swift; sourceTree = "<group>"; };
-		7D46CDF03C9910792DA563A596A1AA6C /* Web3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Web3.swift; path = web3swift/Web3/Classes/Web3.swift; sourceTree = "<group>"; };
-		7E15938B0E01C7540EED1359881D8F0D /* SHA1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA1.swift; path = Sources/CryptoSwift/SHA1.swift; sourceTree = "<group>"; };
-		7EBB7522F3404A3011852D8BD477968A /* StreamEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamEncryptor.swift; path = Sources/CryptoSwift/StreamEncryptor.swift; sourceTree = "<group>"; };
-		7F4EDAD930B01C250C0F748F8CA2C7CC /* BatchedCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BatchedCollection.swift; path = Sources/CryptoSwift/BatchedCollection.swift; sourceTree = "<group>"; };
-		8086578C0DC7EF0622EC041A26E4814C /* Bit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Bit.swift; path = Sources/CryptoSwift/Bit.swift; sourceTree = "<group>"; };
-		824FFA281F8D34B24AFC5F28C8BCB67E /* field_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_impl.h; path = secp256k1_ios/src/field_impl.h; sourceTree = "<group>"; };
-		82F8E69AD4D298893B6FC2CD10F86868 /* SipHash.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SipHash.xcconfig; sourceTree = "<group>"; };
-		831D4E4706C7D1131BA808C8CC6B2407 /* scrypt-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "scrypt-umbrella.h"; sourceTree = "<group>"; };
-		8353E7ABE22A3D8C80B5560B6C664C65 /* Multiplication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Multiplication.swift; path = sources/Multiplication.swift; sourceTree = "<group>"; };
-		83F67535422CCA74B29B5F1CE1572FD2 /* lax_der_privatekey_parsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = lax_der_privatekey_parsing.h; path = secp256k1_ios/contrib/lax_der_privatekey_parsing.h; sourceTree = "<group>"; };
-		8452179E7393B2FA7CE61DE683FF7D73 /* QRCodeReaderViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderViewController.swift; path = Sources/QRCodeReaderViewController.swift; sourceTree = "<group>"; };
-		86A8C87298BB26C969E9D9D731E59D54 /* main_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = main_impl.h; path = secp256k1_ios/src/modules/recovery/main_impl.h; sourceTree = "<group>"; };
-		86AF320F445F837D3DF7F3CA83C7E676 /* BlockDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockDecryptor.swift; path = Sources/CryptoSwift/BlockDecryptor.swift; sourceTree = "<group>"; };
-		86FC360AE9099D7D5A4F0FD29FE481E1 /* web3swift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "web3swift-prefix.pch"; sourceTree = "<group>"; };
-		88250D10A20EEB815A6E14FD5192E74D /* ComparisonExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ComparisonExtensions.swift; path = web3swift/Contract/Classes/ComparisonExtensions.swift; sourceTree = "<group>"; };
-		886A1282A062E66825671DF657D44E64 /* EthereumTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumTransaction.swift; path = web3swift/Transaction/Classes/EthereumTransaction.swift; sourceTree = "<group>"; };
-		8AC375F014CAD55484ACDE4DD147AFAC /* field_10x26.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_10x26.h; path = secp256k1_ios/src/field_10x26.h; sourceTree = "<group>"; };
-		8B887CA868DF2DE1DB203D6F4FE718AC /* PKCS5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS5.swift; path = Sources/CryptoSwift/PKCS/PKCS5.swift; sourceTree = "<group>"; };
-		8C551C86FF3B824BF8A787414B675472 /* num_gmp_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_gmp_impl.h; path = secp256k1_ios/src/num_gmp_impl.h; sourceTree = "<group>"; };
-		8D8675FDA4BA5887BCD243BBD6DFAA05 /* eckey_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = eckey_impl.h; path = secp256k1_ios/src/eckey_impl.h; sourceTree = "<group>"; };
+		70BCFDA3C56415A6D1EB95194CF8B592 /* PBKDF1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF1.swift; path = Sources/CryptoSwift/PKCS/PBKDF1.swift; sourceTree = "<group>"; };
+		70BE5D5DB99C60B6ECB4AA4CDCECFCC4 /* HKDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HKDF.swift; path = Sources/CryptoSwift/HKDF.swift; sourceTree = "<group>"; };
+		720C933C8917AAD3A9F20BCA98ACC3E6 /* QRCodeReader.swift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = QRCodeReader.swift.xcconfig; sourceTree = "<group>"; };
+		736443A191D489AACD7786CE2779EE6A /* NetworkReachabilityManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkReachabilityManager.swift; path = Source/NetworkReachabilityManager.swift; sourceTree = "<group>"; };
+		7475B3B61C275359424F637C0994879B /* Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Operators.swift; path = Sources/CryptoSwift/Operators.swift; sourceTree = "<group>"; };
+		7494F2FF241624C4C0B13986744BA168 /* lax_der_parsing.c */ = {isa = PBXFileReference; includeInIndex = 1; name = lax_der_parsing.c; path = secp256k1_ios/contrib/lax_der_parsing.c; sourceTree = "<group>"; };
+		754C8F70937EC24C697F6128DEA15C39 /* SipHashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SipHashable.swift; path = SipHash/SipHashable.swift; sourceTree = "<group>"; };
+		7782FBF474D27894445865F06B1F5AC2 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "Sources/CryptoSwift/String+Extension.swift"; sourceTree = "<group>"; };
+		78100FEA5A147FDAC8E526311C18EE60 /* Web3+Protocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Protocols.swift"; path = "web3swift/Web3/Classes/Web3+Protocols.swift"; sourceTree = "<group>"; };
+		7832791EE18B0023B28AAAC9039EE90F /* AFError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AFError.swift; path = Source/AFError.swift; sourceTree = "<group>"; };
+		7AC84DAA646EBB604B4ED6B56F4D44F7 /* group_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = group_impl.h; path = secp256k1_ios/src/group_impl.h; sourceTree = "<group>"; };
+		7B719F0183CEE01B32C1F07763F2613A /* Process+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Process+Promise.swift"; path = "Extensions/Foundation/Sources/Process+Promise.swift"; sourceTree = "<group>"; };
+		7DA768214F620DEBF8CB0659D04D1A5B /* util.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = util.h; path = secp256k1_ios/src/util.h; sourceTree = "<group>"; };
+		7E196127E64DF41026ECBAD011870259 /* ABIv2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2.swift; path = web3swift/ABIv2/Classes/ABIv2.swift; sourceTree = "<group>"; };
+		7F25A24DD78BCF6EDFB6B16B1BD7BA43 /* Answers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Answers.h; path = iOS/Crashlytics.framework/Headers/Answers.h; sourceTree = "<group>"; };
+		7F4C3BB6186F689B7AE840596A84078B /* NSObject+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSObject+Promise.swift"; path = "Extensions/Foundation/Sources/NSObject+Promise.swift"; sourceTree = "<group>"; };
+		7F5EF4474394372C33D5AD7DF8A0065C /* GCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GCM.swift; path = Sources/CryptoSwift/BlockMode/GCM.swift; sourceTree = "<group>"; };
+		7FDF73BA0AACCB5EA52DB51BCF9CE9C8 /* hash_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash_impl.h; path = secp256k1_ios/src/hash_impl.h; sourceTree = "<group>"; };
+		7FF820BE0E9F0B29D4E6A63A9E9CA7A6 /* hang.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = hang.m; path = Sources/hang.m; sourceTree = "<group>"; };
+		80EC6B707DF6C990C65CD05DA0301567 /* ParameterEncoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParameterEncoding.swift; path = Source/ParameterEncoding.swift; sourceTree = "<group>"; };
+		823DAA23988145C04C357EBFCE95FAA4 /* PromiseKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PromiseKit-dummy.m"; sourceTree = "<group>"; };
+		836ED2ADDCB705E25214F2432D3EDE48 /* Web3+Eth+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Eth+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/Web3+Eth+ObjC.swift"; sourceTree = "<group>"; };
+		8593E76FB1B8AB27CB5F8CAFC9E5CE6A /* RandomBytesSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RandomBytesSequence.swift; path = Sources/CryptoSwift/RandomBytesSequence.swift; sourceTree = "<group>"; };
+		863D9CD5899EB41A44D01D4787039F50 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		868CA8B8525183BB82B5B7EC40669EFA /* Box.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Box.swift; path = Sources/Box.swift; sourceTree = "<group>"; };
+		86A69359324812DC9B4294B6EC6A9D11 /* Alamofire-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Alamofire-prefix.pch"; sourceTree = "<group>"; };
+		87005B64D352C9CF9D7A7B052F8733B5 /* QRCodeReader.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = QRCodeReader.framework; path = QRCodeReader.swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		871136A970C2EE6E1F4E02424D526B91 /* AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AnyPromise.h; path = Sources/AnyPromise.h; sourceTree = "<group>"; };
+		87C4E22693024283CEF1CE5EC99BFEF1 /* Array+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Array+Foundation.swift"; sourceTree = "<group>"; };
+		87CD8CAF81719B2EC20415813486947E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8882CE2764E4BE56DF60C9E9657CA9F3 /* eckey_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = eckey_impl.h; path = secp256k1_ios/src/eckey_impl.h; sourceTree = "<group>"; };
+		88B076EAAB85640AB48F8818F0C83657 /* Timeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Timeline.swift; path = Source/Timeline.swift; sourceTree = "<group>"; };
+		88F992F8D3048AAA721EAF25366808A9 /* hash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash.h; path = secp256k1_ios/src/hash.h; sourceTree = "<group>"; };
+		894917C6A99D4E63593BC49A81275AA2 /* NativeTypesEncoding+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NativeTypesEncoding+Extensions.swift"; path = "web3swift/Convenience/Classes/NativeTypesEncoding+Extensions.swift"; sourceTree = "<group>"; };
+		8A1D530F1E6B73BA3641C9DA7D783CEC /* BigInt.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = BigInt.modulemap; sourceTree = "<group>"; };
+		8A96BA88952EE60DACD64504880387B6 /* CMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CMAC.swift; path = Sources/CryptoSwift/CMAC.swift; sourceTree = "<group>"; };
+		8B28B0A2B21362D0A9AD85EA2466BDC5 /* QRCodeReaderViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderViewController.swift; path = Sources/QRCodeReaderViewController.swift; sourceTree = "<group>"; };
+		8C052F06433005A8A6C466DFD2D5C585 /* web3swift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "web3swift-umbrella.h"; sourceTree = "<group>"; };
+		8C3F9B931E5DF95AFAF706D8FA6CC55C /* Comparable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Comparable.swift; path = sources/Comparable.swift; sourceTree = "<group>"; };
+		8CEDC0A46453491F47C267BB99CA85A7 /* EIP681.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EIP681.swift; path = web3swift/Utils/Classes/EIP681.swift; sourceTree = "<group>"; };
 		8DBBEE0989B31EB39158B86B75017F25 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		8F4412AEA55497300EA717D896E7EDC8 /* PromiseKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-prefix.pch"; sourceTree = "<group>"; };
-		8FA31A44D782F31BF67CBA776CC6E024 /* QRCodeReader.swift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "QRCodeReader.swift-prefix.pch"; sourceTree = "<group>"; };
-		8FA5CD8CA42EE780A45DA782A0A7556F /* CLSStackFrame.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLSStackFrame.h; path = iOS/Crashlytics.framework/Headers/CLSStackFrame.h; sourceTree = "<group>"; };
-		8FD7D8C6393417BDBE5CF9362727B144 /* ABIv2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2.swift; path = web3swift/ABIv2/Classes/ABIv2.swift; sourceTree = "<group>"; };
-		8FE69ED3CCD20098717723EC70FBA476 /* Promise+Web3+Personal+Sign.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Personal+Sign.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Personal+Sign.swift"; sourceTree = "<group>"; };
-		90C8F8375B636A25054B8B6C8A00DAE0 /* web3swift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "web3swift-umbrella.h"; sourceTree = "<group>"; };
-		9109844DAD13D5EA4994FE47EAC8E7B6 /* scalar_4x64_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_4x64_impl.h; path = secp256k1_ios/src/scalar_4x64_impl.h; sourceTree = "<group>"; };
-		922C288F68253A0F8165786CEEDC1634 /* SipHashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SipHashable.swift; path = SipHash/SipHashable.swift; sourceTree = "<group>"; };
+		8FD8FE5B63CA9FD72BE519AF59F5E1B9 /* ecmult_const_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_const_impl.h; path = secp256k1_ios/src/ecmult_const_impl.h; sourceTree = "<group>"; };
+		901D5132242D3951B5833E7F5E0BBB00 /* scalar_4x64_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_4x64_impl.h; path = secp256k1_ios/src/scalar_4x64_impl.h; sourceTree = "<group>"; };
+		917317E7E493C550E2E327E0D1616711 /* Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Padding.swift; path = Sources/CryptoSwift/Padding.swift; sourceTree = "<group>"; };
+		91FCC94DF64D415579856A46E9AE144F /* Bit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Bit.swift; path = Sources/CryptoSwift/Bit.swift; sourceTree = "<group>"; };
 		926FF01D3631C4B352ACD3055A9C732C /* Pods-DiveLane-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-DiveLane-resources.sh"; sourceTree = "<group>"; };
-		92C45C929132142FE6689C2C4ED07BC5 /* EthereumKeystoreV3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumKeystoreV3.swift; path = web3swift/KeystoreManager/Classes/EthereumKeystoreV3.swift; sourceTree = "<group>"; };
-		9321D523FB42C52138CF67410DF7C696 /* Process+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Process+Promise.swift"; path = "Extensions/Foundation/Sources/Process+Promise.swift"; sourceTree = "<group>"; };
-		9334E5543C9956623D4BFAA9E0560258 /* CTR.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CTR.swift; path = Sources/CryptoSwift/BlockMode/CTR.swift; sourceTree = "<group>"; };
+		92A558EE489C6417A46A979E39DCE1BD /* CryptoSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-umbrella.h"; sourceTree = "<group>"; };
+		930ABC6D2AB929B6B0B0EF49AB3FF50B /* UIView+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+AnyPromise.h"; path = "Extensions/UIKit/Sources/UIView+AnyPromise.h"; sourceTree = "<group>"; };
+		934C1504034E7C96CF606D636CA3FFF9 /* ANSCompatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ANSCompatibility.h; path = iOS/Crashlytics.framework/Headers/ANSCompatibility.h; sourceTree = "<group>"; };
+		937EB2F54E66DF5CEDFB6F004E8F1F2E /* PMKFoundation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PMKFoundation.h; path = Extensions/Foundation/Sources/PMKFoundation.h; sourceTree = "<group>"; };
+		939E4127DFDB5C703CBE8DC97714FD01 /* Notifications.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Notifications.swift; path = Source/Notifications.swift; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		946A2B9F0FFB6DC6145CD5838ED9DF46 /* MD5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MD5.swift; path = Sources/CryptoSwift/MD5.swift; sourceTree = "<group>"; };
-		95DDFD2F47B41B96FBDF82BB79C4DA9F /* basic-config.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "basic-config.h"; path = "secp256k1_ios/src/basic-config.h"; sourceTree = "<group>"; };
-		968A1F9CB0E9C9ABD4D80279F7EA55AD /* Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Promise.swift; path = Sources/Promise.swift; sourceTree = "<group>"; };
-		96AC6410BC3F9BBCCD4AE87C8A69D8A6 /* Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Operators.swift; path = Sources/CryptoSwift/Operators.swift; sourceTree = "<group>"; };
-		984F3E1BD001B0D5BEC00D1601FE7420 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9914D1F2AE3E2341EE53A6C12D075E42 /* PMKFoundation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PMKFoundation.h; path = Extensions/Foundation/Sources/PMKFoundation.h; sourceTree = "<group>"; };
+		93CEC7DE4894315B947D9A24501EC842 /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fabric.framework; path = iOS/Fabric.framework; sourceTree = "<group>"; };
+		93DBBC54280BEBF480E364971D5239C7 /* ResultProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResultProtocol.swift; path = Result/ResultProtocol.swift; sourceTree = "<group>"; };
+		94F095D6675E92DB361EBD6ED6641597 /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "Sources/CryptoSwift/Array+Extension.swift"; sourceTree = "<group>"; };
+		96258CEA10BDDD00990C9B904A3AA9D2 /* Integer Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Integer Conversion.swift"; path = "sources/Integer Conversion.swift"; sourceTree = "<group>"; };
+		96803255870FC0B988C5D3FF3EC38DF5 /* scalar_8x32.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_8x32.h; path = secp256k1_ios/src/scalar_8x32.h; sourceTree = "<group>"; };
+		96D1D17378722BAD8574D405DC1F248B /* UIView+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+AnyPromise.m"; path = "Extensions/UIKit/Sources/UIView+AnyPromise.m"; sourceTree = "<group>"; };
+		98E41E2D43AA4B11B56B0F45BBAC5738 /* Promise+Web3+Eth+GetBlockByNumber.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetBlockByNumber.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetBlockByNumber.swift"; sourceTree = "<group>"; };
+		99978E9C44BDF8277225A7AD3CD7D0E6 /* Web3+Instance.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Instance.swift"; path = "web3swift/Web3/Classes/Web3+Instance.swift"; sourceTree = "<group>"; };
 		9A44858F0AC10AF9C542E465BB61E77B /* Pods-DiveLane.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-DiveLane.modulemap"; sourceTree = "<group>"; };
-		9A8E5CCAA68BC39EC9E90A422E2FD22B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9C0CCD3ADD8A757A11862385A5B31AF4 /* UInt16+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt16+Extension.swift"; path = "Sources/CryptoSwift/UInt16+Extension.swift"; sourceTree = "<group>"; };
-		9C1B25B4A57B80C024DAF4169CBD5738 /* QRCodeReaderViewControllerBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderViewControllerBuilder.swift; path = Sources/QRCodeReaderViewControllerBuilder.swift; sourceTree = "<group>"; };
+		9A58C40C1A7DB1C8A734F1436A9490FA /* QRCodeReader.swift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "QRCodeReader.swift-dummy.m"; sourceTree = "<group>"; };
+		9A6F5312645A6EE3C6E58F47D7966B1F /* secp256k1_ios.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = secp256k1_ios.modulemap; sourceTree = "<group>"; };
+		9BC61D2173A7D897CEE43E9ED30B3858 /* Collection+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Collection+Extension.swift"; path = "Sources/CryptoSwift/Collection+Extension.swift"; sourceTree = "<group>"; };
+		9CBB1FE361AE2CCD511B0C4C5EB4F94C /* Strideable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strideable.swift; path = sources/Strideable.swift; sourceTree = "<group>"; };
 		9CBEC0B2EAEEFCDF5D11A9E90C1A3EFB /* Pods-DiveLane-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-DiveLane-frameworks.sh"; sourceTree = "<group>"; };
-		9E7CCA70CB80C09C9A5A309B5A9C697E /* NameHash.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NameHash.swift; path = web3swift/Utils/Classes/NameHash.swift; sourceTree = "<group>"; };
-		A00EF881409ABAAA333E7D4C52F6FA0B /* Web3+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Utils.swift"; path = "web3swift/Web3/Classes/Web3+Utils.swift"; sourceTree = "<group>"; };
-		A0C1173CE60CDE5D71AF73564BBEF041 /* PCBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PCBC.swift; path = Sources/CryptoSwift/BlockMode/PCBC.swift; sourceTree = "<group>"; };
-		A1785C3404F91CD2610553CAD01F14B0 /* PBKDF1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF1.swift; path = Sources/CryptoSwift/PKCS/PBKDF1.swift; sourceTree = "<group>"; };
-		A2D8F9E8F18C8FE7181B08A0B71CA1A1 /* after.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = after.swift; path = Sources/after.swift; sourceTree = "<group>"; };
-		A3BECC646855C9D5F421B3EA83BF6EC9 /* Web3+Structures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Structures.swift"; path = "web3swift/Web3/Classes/Web3+Structures.swift"; sourceTree = "<group>"; };
-		A41C3E6A280C712951F4529D21BF46A9 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "web3swift/Convenience/Classes/String+Extension.swift"; sourceTree = "<group>"; };
-		A5BDC2A70C176E4B5CE53439F29006B0 /* ABIv2ParameterTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2ParameterTypes.swift; path = web3swift/ABIv2/Classes/ABIv2ParameterTypes.swift; sourceTree = "<group>"; };
-		A760383154BE7CDD10490704A13AF43E /* Web3+Instance.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Instance.swift"; path = "web3swift/Web3/Classes/Web3+Instance.swift"; sourceTree = "<group>"; };
-		A91184E78522CDA56B22FF1EDB1C3AC1 /* CryptoSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-umbrella.h"; sourceTree = "<group>"; };
-		A9267DC4FB6FB0541831558AA6F2EC0F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		AA5D7F458AEE45A98CE2A88398BCB385 /* Promise+Web3+Eth+GetTransactionCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetTransactionCount.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetTransactionCount.swift"; sourceTree = "<group>"; };
-		AA9E33D7B35D7414F58825BD46C796BB /* Cipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cipher.swift; path = Sources/CryptoSwift/Cipher.swift; sourceTree = "<group>"; };
-		AE2F6C3989B7DC36E54BF9F72856E6F1 /* secp256k1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = secp256k1.c; path = secp256k1_ios/src/secp256k1.c; sourceTree = "<group>"; };
-		AEE7DAE7FE8050EFB9EAEA05710A4984 /* Rabbit+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Rabbit+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Rabbit+Foundation.swift"; sourceTree = "<group>"; };
-		AF007536B0CAD11C81F81E5AEAEF96C5 /* Promise+Web3+Eth+GetBalance.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetBalance.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetBalance.swift"; sourceTree = "<group>"; };
-		AF6107660A564CA761AD2EE8C3D92E78 /* BigInt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BigInt.swift; path = sources/BigInt.swift; sourceTree = "<group>"; };
-		B114219677B4C10C3E66F96A5BC6DD81 /* UInt64+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt64+Extension.swift"; path = "Sources/CryptoSwift/UInt64+Extension.swift"; sourceTree = "<group>"; };
-		B2D0C7941B416A9892CDDBD96789C132 /* Result-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Result-dummy.m"; sourceTree = "<group>"; };
-		B30A1A7519934D9C2130711A3D73EA88 /* UIView+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+AnyPromise.m"; path = "Extensions/UIKit/Sources/UIView+AnyPromise.m"; sourceTree = "<group>"; };
-		B3CFB7A375AE11906A99E54EE63DE37D /* QRCodeReader.swift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = QRCodeReader.swift.xcconfig; sourceTree = "<group>"; };
-		B42AE7B67420B67F1EACEBB856F114C6 /* Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Padding.swift; path = Sources/CryptoSwift/Padding.swift; sourceTree = "<group>"; };
-		B45CEDB397684979E7A94F5717A7DFB8 /* AES+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AES+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/AES+Foundation.swift"; sourceTree = "<group>"; };
-		B6761F1748940B1DDC2C2B4EC1A2A625 /* scrypt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scrypt.h; path = scrypt/scrypt.h; sourceTree = "<group>"; };
-		B7183803460616976586A715AFC5D10E /* EIP67Code.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EIP67Code.swift; path = web3swift/Utils/Classes/EIP67Code.swift; sourceTree = "<group>"; };
-		B8AE5D5F696161490EDCAAB4F1337C16 /* ECB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ECB.swift; path = Sources/CryptoSwift/BlockMode/ECB.swift; sourceTree = "<group>"; };
-		B8CD9A900727202456B18505B6F9D3AA /* HKDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HKDF.swift; path = Sources/CryptoSwift/HKDF.swift; sourceTree = "<group>"; };
-		B96D5CFB4AFC33326C3B9877B1669AE0 /* ANSCompatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ANSCompatibility.h; path = iOS/Crashlytics.framework/Headers/ANSCompatibility.h; sourceTree = "<group>"; };
-		BA660D6BB71673919923BCD02318CA81 /* BIP39.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BIP39.swift; path = web3swift/KeystoreManager/Classes/BIP39.swift; sourceTree = "<group>"; };
-		BA78A7BEFA2005B4F4984EB44F936189 /* UIView+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+AnyPromise.h"; path = "Extensions/UIKit/Sources/UIView+AnyPromise.h"; sourceTree = "<group>"; };
-		BAD9140A70E4F1E11E22F06BF0413344 /* ABIv2Parsing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2Parsing.swift; path = web3swift/ABIv2/Classes/ABIv2Parsing.swift; sourceTree = "<group>"; };
-		BADE7592EE42D062BA4138EA1897A189 /* KeystoreManager+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "KeystoreManager+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/KeystoreManager+ObjC.swift"; sourceTree = "<group>"; };
-		BB0756499BD68CE88386F1DDE23712AD /* CipherModeWorker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CipherModeWorker.swift; path = Sources/CryptoSwift/BlockMode/CipherModeWorker.swift; sourceTree = "<group>"; };
-		BB13AC3AB426E3CB418672CB306B578B /* field_10x26_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_10x26_impl.h; path = secp256k1_ios/src/field_10x26_impl.h; sourceTree = "<group>"; };
-		BB5427CACBC2CF16837E0169F9898C09 /* ReaderOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReaderOverlayView.swift; path = Sources/ReaderOverlayView.swift; sourceTree = "<group>"; };
-		BEB195D191088CD6E9D8714727A72B1C /* CLSLogging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLSLogging.h; path = iOS/Crashlytics.framework/Headers/CLSLogging.h; sourceTree = "<group>"; };
-		BF2B2DA5A2561B9D5D3EAFD2BD989D64 /* eckey.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = eckey.h; path = secp256k1_ios/src/eckey.h; sourceTree = "<group>"; };
-		BF8B7DC811049895554DA6E7651A5692 /* web3swift.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = web3swift.h; path = web3swift/web3swift.h; sourceTree = "<group>"; };
-		BFC1B01C1779486510931BD394A8BDF9 /* Data Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data Conversion.swift"; path = "sources/Data Conversion.swift"; sourceTree = "<group>"; };
-		C058AEDF0EDDEDF0E6CD7FFD7ACD7DBC /* Promise+Web3+Contract+GetIndexedEvents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Contract+GetIndexedEvents.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Contract+GetIndexedEvents.swift"; sourceTree = "<group>"; };
-		C13689EA7380E49B83A5D99C87E16871 /* CustomStringConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomStringConvertible.swift; path = Sources/CustomStringConvertible.swift; sourceTree = "<group>"; };
-		C1EAE8C76427A933698DEB3D56A3427A /* String Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String Conversion.swift"; path = "sources/String Conversion.swift"; sourceTree = "<group>"; };
-		C1FE37645FB80882CAF3C4AB67585742 /* Integer Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Integer Conversion.swift"; path = "sources/Integer Conversion.swift"; sourceTree = "<group>"; };
+		9D48A17683BDECE084550AA6339F9CEC /* secp256k1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = secp256k1.c; path = secp256k1_ios/src/secp256k1.c; sourceTree = "<group>"; };
+		9E1D1283598DD9FB40501814B446C432 /* BlockEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockEncryptor.swift; path = Sources/CryptoSwift/BlockEncryptor.swift; sourceTree = "<group>"; };
+		9E2290B9A60E8498F813AE6510A42F13 /* Primitive Types.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Primitive Types.swift"; path = "SipHash/Primitive Types.swift"; sourceTree = "<group>"; };
+		9F29B0076CE93A7FC836359D228078A9 /* secp256k1_ios.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_ios.h; path = secp256k1_ios/secp256k1_ios.h; sourceTree = "<group>"; };
+		9F7EFD8D6B5A34686C4E7CC299B952B8 /* CLSLogging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLSLogging.h; path = iOS/Crashlytics.framework/Headers/CLSLogging.h; sourceTree = "<group>"; };
+		A072AF0ACC773EF3B8B92B46FEC26400 /* PromiseKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PromiseKit.xcconfig; sourceTree = "<group>"; };
+		A0A296B44654179E862676929D0D08A4 /* field_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_impl.h; path = secp256k1_ios/src/field_impl.h; sourceTree = "<group>"; };
+		A23101FBFEBC11DD104C764E8151CD01 /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PromiseKit.framework; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A231571D3499DDA617E10EEA78857D32 /* CustomStringConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomStringConvertible.swift; path = Sources/CustomStringConvertible.swift; sourceTree = "<group>"; };
+		A2573C14613EBF2FC6834A49B8139389 /* CLSAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLSAttributes.h; path = iOS/Crashlytics.framework/Headers/CLSAttributes.h; sourceTree = "<group>"; };
+		A380ABE0FF9C088B8F0379EECF25B523 /* GCD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GCD.swift; path = sources/GCD.swift; sourceTree = "<group>"; };
+		A3871425630F3D873F76F3BC235328D5 /* Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = Sources/CryptoSwift/Utils.swift; sourceTree = "<group>"; };
+		A45716CD51A52B4C4E37E747A142CC84 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A4EFCF9E0550A93DEB58F8D4FF35A5A2 /* Thenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Thenable.swift; path = Sources/Thenable.swift; sourceTree = "<group>"; };
+		A523F91DD68A69492E50FEE51152D552 /* Web3+ERC20.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+ERC20.swift"; path = "web3swift/PrecompiledContracts/ERC20/Web3+ERC20.swift"; sourceTree = "<group>"; };
+		A6A0705AACC34D9047350BA409367FD3 /* EthereumFilterEncodingExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumFilterEncodingExtensions.swift; path = web3swift/Contract/Classes/EthereumFilterEncodingExtensions.swift; sourceTree = "<group>"; };
+		A728C96D2D6447B46FB27C5908606294 /* Cimpl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Cimpl.h; path = scrypt/Cimpl.h; sourceTree = "<group>"; };
+		A79DB94B5E2289A1FDE5D100D10433F4 /* String+FoundationExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+FoundationExtension.swift"; path = "Sources/CryptoSwift/Foundation/String+FoundationExtension.swift"; sourceTree = "<group>"; };
+		A81BD1624603AFA149D3E661A842C8CE /* Promise+Batching.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Batching.swift"; path = "web3swift/Promises/Classes/Promise+Batching.swift"; sourceTree = "<group>"; };
+		A84FAB4B01608C152C252FB69EF57D28 /* Digest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Digest.swift; path = Sources/CryptoSwift/Digest.swift; sourceTree = "<group>"; };
+		A8796A6C08F8592D9CE812BD9B184C87 /* QRCodeReaderViewContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderViewContainer.swift; path = Sources/QRCodeReaderViewContainer.swift; sourceTree = "<group>"; };
+		A88E1E37AA32CDBC72132AC7BDD7FE7B /* ecdsa_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdsa_impl.h; path = secp256k1_ios/src/ecdsa_impl.h; sourceTree = "<group>"; };
+		A8D72BD9A6E8FD6F0F5846DCD6B06878 /* field_5x52_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_impl.h; path = secp256k1_ios/src/field_5x52_impl.h; sourceTree = "<group>"; };
+		A9361D2F2F5838E6646F06E68392D728 /* Promise+Web3+Personal+Sign.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Personal+Sign.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Personal+Sign.swift"; sourceTree = "<group>"; };
+		AA3DE8A50B82E65318FC3E2406D9086B /* SipHash.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = SipHash.modulemap; sourceTree = "<group>"; };
+		AAAC75383E246EA11843B677C63C9409 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AAEAD748EABB865472012722BBC282CA /* ReaderOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReaderOverlayView.swift; path = Sources/ReaderOverlayView.swift; sourceTree = "<group>"; };
+		AAECC5EB37FA21B358456B45631F17FF /* Result-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Result-umbrella.h"; sourceTree = "<group>"; };
+		AB6FA2B4E48BAAF86E40E8B34BCCF974 /* Web3+Contract.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Contract.swift"; path = "web3swift/Web3/Classes/Web3+Contract.swift"; sourceTree = "<group>"; };
+		AB7F45E650B4C57D8F5B9F644B28D870 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		ABD42F09517187F64B86B1D785855A84 /* Promise+Web3+Eth+GetAccounts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetAccounts.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetAccounts.swift"; sourceTree = "<group>"; };
+		ABD7F26A557D98A7C91689CB5A60D36D /* PBKDF2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF2.swift; path = Sources/CryptoSwift/PKCS/PBKDF2.swift; sourceTree = "<group>"; };
+		ABE4C1AA983DDFB7CFBD319A1A3354F5 /* ContractABIv2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContractABIv2.swift; path = web3swift/Contract/Classes/ContractABIv2.swift; sourceTree = "<group>"; };
+		ADAB8FD05505F6681B106032F4D674DA /* field.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field.h; path = secp256k1_ios/src/field.h; sourceTree = "<group>"; };
+		AF08B8DF071710D784EFFB10758809CD /* Alamofire-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Alamofire-dummy.m"; sourceTree = "<group>"; };
+		B124045913A60D2E6F4B128D31FB54A1 /* Web3+Wallet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Wallet.swift"; path = "web3swift/HookedFunctions/Classes/Web3+Wallet.swift"; sourceTree = "<group>"; };
+		B15A11FE00702C88874F947C5C5D37DA /* Data+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Extension.swift"; path = "Sources/CryptoSwift/Foundation/Data+Extension.swift"; sourceTree = "<group>"; };
+		B2467C8F75C056D0510A2DC383174166 /* Shifts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Shifts.swift; path = sources/Shifts.swift; sourceTree = "<group>"; };
+		B2DE48CC3A2DFD167480E64360EA9259 /* libsecp256k1-config.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "libsecp256k1-config.h"; path = "secp256k1_ios/libsecp256k1-config.h"; sourceTree = "<group>"; };
+		B4AAF8307C81ED675D28AEDEAA3CA402 /* field_10x26.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_10x26.h; path = secp256k1_ios/src/field_10x26.h; sourceTree = "<group>"; };
+		B5D1E41FC7CE889C03F43819CAC906CC /* UInt16+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt16+Extension.swift"; path = "Sources/CryptoSwift/UInt16+Extension.swift"; sourceTree = "<group>"; };
+		B6473E6D83C12C75419CCA654011714F /* MD5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MD5.swift; path = Sources/CryptoSwift/MD5.swift; sourceTree = "<group>"; };
+		B774B455364008941BBBD9AE3C63743A /* Promise+Web3+Eth+GetBlockNumber.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetBlockNumber.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetBlockNumber.swift"; sourceTree = "<group>"; };
+		B8708AAEEC5CE4CC134AC9BBB41A1832 /* SipHash-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SipHash-prefix.pch"; sourceTree = "<group>"; };
+		B91C43CC342DEECF3EAD2D00DF142834 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BA3019DE0415EB42DFAFD80C013444D7 /* Web3+Infura.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Infura.swift"; path = "web3swift/Web3/Classes/Web3+Infura.swift"; sourceTree = "<group>"; };
+		BA589F8FC69C78A18A71046F844CCF3C /* BlockModeOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockModeOptions.swift; path = Sources/CryptoSwift/BlockMode/BlockModeOptions.swift; sourceTree = "<group>"; };
+		BBB2E83B0870410A5D08B5DF62BC0BB0 /* PromiseKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-umbrella.h"; sourceTree = "<group>"; };
+		BC2A88C86693001FC598E4F8FE65448A /* NSURLSession+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLSession+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSURLSession+AnyPromise.h"; sourceTree = "<group>"; };
+		BC5BEB238DEA66EAD3E72BCD58B993D0 /* Promise+Web3+Eth+Call.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+Call.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+Call.swift"; sourceTree = "<group>"; };
+		BD24CAA8870B6EBFE6E6833B8DD551BD /* Floating Point Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Floating Point Conversion.swift"; path = "sources/Floating Point Conversion.swift"; sourceTree = "<group>"; };
+		BD339B1454B79A6400983A439AF3AE02 /* StreamEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamEncryptor.swift; path = Sources/CryptoSwift/StreamEncryptor.swift; sourceTree = "<group>"; };
+		BD64EE5E17635F522BEC667AE08BAB92 /* main_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = main_impl.h; path = secp256k1_ios/src/modules/recovery/main_impl.h; sourceTree = "<group>"; };
+		BD68A36110A4FCF3C1583F018F78F1FF /* field_5x52_asm_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_asm_impl.h; path = secp256k1_ios/src/field_5x52_asm_impl.h; sourceTree = "<group>"; };
+		BE793F8B74E5CCD76899F63529F9CB04 /* Alamofire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Alamofire.swift; path = Source/Alamofire.swift; sourceTree = "<group>"; };
+		BE9A54A506A81E396702012E6290BB76 /* QRCodeReader.swift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = QRCodeReader.swift.modulemap; sourceTree = "<group>"; };
+		BEA91E988B77C6D1AF10C93F0DE1A23B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BF4CCC3CD81989D23B696E7053A33F40 /* AbstractKeystore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AbstractKeystore.swift; path = web3swift/KeystoreManager/Classes/AbstractKeystore.swift; sourceTree = "<group>"; };
+		C0D2CE11C62E522B7B555D073C66C724 /* String Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String Conversion.swift"; path = "sources/String Conversion.swift"; sourceTree = "<group>"; };
+		C1115E6596EF196DD2291F81C4C9C181 /* scalar_low_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_low_impl.h; path = secp256k1_ios/src/scalar_low_impl.h; sourceTree = "<group>"; };
+		C1BFC8E2A0E61395AB165CA6C1500F71 /* main_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = main_impl.h; path = secp256k1_ios/src/modules/ecdh/main_impl.h; sourceTree = "<group>"; };
+		C227389A3CE55B031095EF269734DD76 /* ABIv2ParameterTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIv2ParameterTypes.swift; path = web3swift/ABIv2/Classes/ABIv2ParameterTypes.swift; sourceTree = "<group>"; };
 		C24C3C440F9FB14B2CAF631D7C6CF3D9 /* Pods-DiveLane.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-DiveLane.release.xcconfig"; sourceTree = "<group>"; };
-		C3DC8E36D9095B4B0AA882FF480B7161 /* Result.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Result.xcconfig; sourceTree = "<group>"; };
-		C43A02AA2A26B7A19A6767BC973BAD85 /* scalar.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar.h; path = secp256k1_ios/src/scalar.h; sourceTree = "<group>"; };
-		C50A145B512B01C48B19A84D643FB5DC /* BufferStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BufferStorage.swift; path = scrypt/scrypt/BufferStorage.swift; sourceTree = "<group>"; };
-		C542891C63483A08B0BE169BA765C23A /* NSNotificationCenter+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.m"; sourceTree = "<group>"; };
-		C57101628C8EDF06BC7342A48269104D /* when.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = when.m; path = Sources/when.m; sourceTree = "<group>"; };
-		C646FB1DA299FF412F9BDC68F40E0E75 /* Promise+Web3+Eth+SendTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+SendTransaction.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+SendTransaction.swift"; sourceTree = "<group>"; };
-		C6C238D4F471736091D3722367119066 /* PKCS7Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7Padding.swift; path = Sources/CryptoSwift/PKCS/PKCS7Padding.swift; sourceTree = "<group>"; };
-		C75A2DBD7913BD159F4A5A5069428A96 /* EthereumAddress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumAddress.swift; path = web3swift/KeystoreManager/Classes/EthereumAddress.swift; sourceTree = "<group>"; };
-		C7C061174C15AD0DCF8A94EA425FBAF5 /* Result-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Result-prefix.pch"; sourceTree = "<group>"; };
-		C939D64636F1F2FFF721FDE6005F2F0D /* ZeroPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ZeroPadding.swift; path = Sources/CryptoSwift/ZeroPadding.swift; sourceTree = "<group>"; };
-		C948126C72F61B79C50B629A1C0D183E /* IBAN.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IBAN.swift; path = web3swift/KeystoreManager/Classes/IBAN.swift; sourceTree = "<group>"; };
-		C98042B15E6438A1708C16E5D4E99EA2 /* BigUInt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BigUInt.swift; path = sources/BigUInt.swift; sourceTree = "<group>"; };
-		CA32154A733AA095D64909273E33AF19 /* web3swift-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "web3swift-Bridging-Header.h"; path = "web3swift/web3swift-Bridging-Header.h"; sourceTree = "<group>"; };
-		CA403788D75396DDF796912329E2CF6B /* CLSReport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLSReport.h; path = iOS/Crashlytics.framework/Headers/CLSReport.h; sourceTree = "<group>"; };
-		CA571F033887A13B9CCA85633781014B /* Result.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Result.modulemap; sourceTree = "<group>"; };
-		CA687D0E7D969684C006B6695B29A09A /* NSNotificationCenter+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.h"; sourceTree = "<group>"; };
-		CA7B4CE9C4365DCA0228DF681C4E2948 /* num_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_impl.h; path = secp256k1_ios/src/num_impl.h; sourceTree = "<group>"; };
+		C2A288328F7FF4DE93CFF3FDDDE072D3 /* EventFiltering.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventFiltering.swift; path = web3swift/Contract/Classes/EventFiltering.swift; sourceTree = "<group>"; };
+		C2F2B3C6389C3B20BA6089734B930EBE /* UIViewPropertyAnimator+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIViewPropertyAnimator+Promise.swift"; path = "Extensions/UIKit/Sources/UIViewPropertyAnimator+Promise.swift"; sourceTree = "<group>"; };
+		C3524EB86E47609DFFFA6E121A73E5CD /* KeystoreV3JSONStructure.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeystoreV3JSONStructure.swift; path = web3swift/KeystoreManager/Classes/KeystoreV3JSONStructure.swift; sourceTree = "<group>"; };
+		C60D5B76E28C82511B6EF078E996882C /* Resolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Resolver.swift; path = Sources/Resolver.swift; sourceTree = "<group>"; };
+		C65CC5DD174B751E11B617617457C6AD /* when.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = when.m; path = Sources/when.m; sourceTree = "<group>"; };
+		C6A17E180C775F133971F5BEA1EC703F /* SHA3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA3.swift; path = Sources/CryptoSwift/SHA3.swift; sourceTree = "<group>"; };
+		C787950D811A87FB57E6DE5D3B1A8DE5 /* basic-config.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "basic-config.h"; path = "secp256k1_ios/src/basic-config.h"; sourceTree = "<group>"; };
+		C8CF67230FE1CA91342AB81CEBB19158 /* AES+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AES+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/AES+Foundation.swift"; sourceTree = "<group>"; };
+		C9AC7A31D4825C72086072BC767F4C1D /* scrypt-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "scrypt-umbrella.h"; sourceTree = "<group>"; };
+		C9AF4BA027E7452FA710EAC1913382A1 /* Salsa.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Salsa.swift; path = scrypt/scrypt/Salsa.swift; sourceTree = "<group>"; };
 		CA855DC6412290B5286A9DD3D5F8FA5E /* secp256k1_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = secp256k1_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CAB3CE396AC863066AAF026DEB3D6551 /* Web3+HttpProvider+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+HttpProvider+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/Web3+HttpProvider+ObjC.swift"; sourceTree = "<group>"; };
-		CB48D68DCB17B1C07B05A6D6B3EDC766 /* Web3+HttpProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+HttpProvider.swift"; path = "web3swift/Web3/Classes/Web3+HttpProvider.swift"; sourceTree = "<group>"; };
-		CC93974BF783269BAC12B91F8592233D /* Promise+Web3+Eth+GetBlockByHash.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetBlockByHash.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetBlockByHash.swift"; sourceTree = "<group>"; };
-		CDE57327670FC8906B9D407E2D978DD5 /* NoError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoError.swift; path = Result/NoError.swift; sourceTree = "<group>"; };
-		CE8979EDA54F76059818F7D9272FDDCB /* QRCodeReader.swift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "QRCodeReader.swift-dummy.m"; sourceTree = "<group>"; };
-		CF68056D625032F4519B4087C11B8241 /* Cimpl.c */ = {isa = PBXFileReference; includeInIndex = 1; name = Cimpl.c; path = scrypt/Cimpl.c; sourceTree = "<group>"; };
-		D0CDDBC20612961CC37CD4D522A380D3 /* Int+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Int+Extension.swift"; path = "Sources/CryptoSwift/Int+Extension.swift"; sourceTree = "<group>"; };
-		D2A9342EAD85D9110FF0B04FCF37DA4F /* SHA3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA3.swift; path = Sources/CryptoSwift/SHA3.swift; sourceTree = "<group>"; };
-		D2F4E98031D70399B7BAA04C8BA36D16 /* Promise+Web3+Eth+GetAccounts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetAccounts.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetAccounts.swift"; sourceTree = "<group>"; };
-		D388102D4167E26F5F588350B86F0E22 /* secp256k1_ios.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = secp256k1_ios.modulemap; sourceTree = "<group>"; };
-		D38CE9424BB10682C68AC1F0EAE2F0DA /* Words and Bits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Words and Bits.swift"; path = "sources/Words and Bits.swift"; sourceTree = "<group>"; };
+		CBB6967D78BDD324F6C6F7152A13DCF3 /* PlainKeystore+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PlainKeystore+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/PlainKeystore+ObjC.swift"; sourceTree = "<group>"; };
+		CCEB6BCBCF2FA9650F28438EF13B70FA /* BlockExplorer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockExplorer.swift; path = web3swift/BlockExplorer/Classes/BlockExplorer.swift; sourceTree = "<group>"; };
+		CDB95A76496EDC5724E41797B5EE2F51 /* BlockMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockMode.swift; path = Sources/CryptoSwift/BlockMode/BlockMode.swift; sourceTree = "<group>"; };
+		CDFEF8A63F93FB41D6119F765F6D3B0C /* Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Poly1305.swift; path = Sources/CryptoSwift/Poly1305.swift; sourceTree = "<group>"; };
+		CE1FBDE0FB577612625318231AE57033 /* secp256k1_ios-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "secp256k1_ios-dummy.m"; sourceTree = "<group>"; };
+		CE5299483F73A2F9F3D986E18B127574 /* Subtraction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Subtraction.swift; path = sources/Subtraction.swift; sourceTree = "<group>"; };
+		CEA2FA56B1D5976585D96D52DE483E3D /* SipHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SipHash.framework; path = SipHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CF3472CD4D6EC8A85F4709A83062E589 /* ecmult_gen_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_gen_impl.h; path = secp256k1_ios/src/ecmult_gen_impl.h; sourceTree = "<group>"; };
+		CF458B3B854F09D3F06D88AC6EAAC0EE /* ComparisonExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ComparisonExtensions.swift; path = web3swift/Contract/Classes/ComparisonExtensions.swift; sourceTree = "<group>"; };
+		D018E84EED83CC3078FCCD3270F2ADAF /* DispatchQueue+Alamofire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DispatchQueue+Alamofire.swift"; path = "Source/DispatchQueue+Alamofire.swift"; sourceTree = "<group>"; };
+		D05C3368C5FD7ECC5190CD02861FC492 /* Promise+HttpProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+HttpProvider.swift"; path = "web3swift/Promises/Classes/Promise+HttpProvider.swift"; sourceTree = "<group>"; };
+		D343411628B4DF169F56E7AFE870A582 /* Web3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Web3.swift; path = web3swift/Web3/Classes/Web3.swift; sourceTree = "<group>"; };
+		D3679BBFDE812DA031A88BA78BA37E13 /* Web3+Structures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Structures.swift"; path = "web3swift/Web3/Classes/Web3+Structures.swift"; sourceTree = "<group>"; };
+		D38BB6B56E3E88A1D6E48D0DE5D6364D /* Guarantee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Guarantee.swift; path = Sources/Guarantee.swift; sourceTree = "<group>"; };
 		D39111F8BB1FF59EA7FEBF78FDA105EB /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D3DBEC6C530117F3405599A1A23356FF /* Collection+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Collection+Extension.swift"; path = "Sources/CryptoSwift/Collection+Extension.swift"; sourceTree = "<group>"; };
-		D439BB66554D1352661D93A5B8DCC2CD /* Prime Test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Prime Test.swift"; path = "sources/Prime Test.swift"; sourceTree = "<group>"; };
-		D4BD253F42CDC5D32643550402722E85 /* Digest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Digest.swift; path = Sources/CryptoSwift/Digest.swift; sourceTree = "<group>"; };
-		D51DD83364DA2F39BA950E45A16A9374 /* ToggleTorchButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToggleTorchButton.swift; path = Sources/ToggleTorchButton.swift; sourceTree = "<group>"; };
-		D5617684FF7E52B38B69C71ADE69269D /* Bitwise Ops.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bitwise Ops.swift"; path = "sources/Bitwise Ops.swift"; sourceTree = "<group>"; };
-		D5B92DF881BDEE17A066C7CEB0832AF4 /* Promise+Web3+Eth+GetGasPrice.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetGasPrice.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetGasPrice.swift"; sourceTree = "<group>"; };
-		D6B66623F19008617D078D938B35FA5E /* Addition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Addition.swift; path = sources/Addition.swift; sourceTree = "<group>"; };
-		D6C1DEAB322EB0D48D628D067BA01A90 /* PMKUIKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PMKUIKit.h; path = Extensions/UIKit/Sources/PMKUIKit.h; sourceTree = "<group>"; };
+		D46CC1978DC1AFE01C606CAE78F5EB25 /* Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Response.swift; path = Source/Response.swift; sourceTree = "<group>"; };
+		D5231B7A7C9D35B5D55A46943A58E7FD /* PKCS7Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7Padding.swift; path = Sources/CryptoSwift/PKCS/PKCS7Padding.swift; sourceTree = "<group>"; };
 		D7065A796E6B04F32F1944EA52ED3F03 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/CoreImage.framework; sourceTree = DEVELOPER_DIR; };
-		D97A5FA3F03B5FC2E2E8D181D2D00D06 /* Array+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Array+Foundation.swift"; sourceTree = "<group>"; };
-		DA2BE125C18E4B43224734B6002B0467 /* Web3+Eth.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Eth.swift"; path = "web3swift/Web3/Classes/Web3+Eth.swift"; sourceTree = "<group>"; };
-		DA3B8C705156CC5A9B627D04D4B8CE8A /* lax_der_parsing.c */ = {isa = PBXFileReference; includeInIndex = 1; name = lax_der_parsing.c; path = secp256k1_ios/contrib/lax_der_parsing.c; sourceTree = "<group>"; };
-		DC7523489901E7C1E4B20D907A43196A /* scrypt-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "scrypt-dummy.m"; sourceTree = "<group>"; };
-		DDEEC3EBA384B1DDF7CE41B1E9B2E753 /* QRCodeReaderResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderResult.swift; path = Sources/QRCodeReaderResult.swift; sourceTree = "<group>"; };
-		DE93D1B7D324256F9D4C18FECD6123C5 /* RIPEMD160+StackOveflow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "RIPEMD160+StackOveflow.swift"; path = "web3swift/Convenience/Classes/RIPEMD160+StackOveflow.swift"; sourceTree = "<group>"; };
-		DF49644077A1B25CAA8CF54D4DBC095D /* Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Random.swift; path = sources/Random.swift; sourceTree = "<group>"; };
-		DFF18856CBCE4C2A15E7E8D5634BE7EF /* UIViewController+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+AnyPromise.m"; path = "Extensions/UIKit/Sources/UIViewController+AnyPromise.m"; sourceTree = "<group>"; };
-		E0F5F8C80C4653B3EBF1B9795FD9B567 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D72B89AF39754D5394CDDA89EF1FE910 /* CTR.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CTR.swift; path = Sources/CryptoSwift/BlockMode/CTR.swift; sourceTree = "<group>"; };
+		D79791C3084EDB6DCB40FDB9CC457AC1 /* ECB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ECB.swift; path = Sources/CryptoSwift/BlockMode/ECB.swift; sourceTree = "<group>"; };
+		D841A94F02EE18231C3A6082413C6926 /* Blowfish+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Blowfish+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Blowfish+Foundation.swift"; sourceTree = "<group>"; };
+		D8669ED437B4269BEA0E9FA54AACDF9A /* QRCodeReaderResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderResult.swift; path = Sources/QRCodeReaderResult.swift; sourceTree = "<group>"; };
+		D8E47EB0AFC3A421CC5AB0E56AABFBA8 /* SecureBytes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecureBytes.swift; path = Sources/CryptoSwift/SecureBytes.swift; sourceTree = "<group>"; };
+		D92CEF49FC2D0F46DDBF5F67D4400DD9 /* hang.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = hang.swift; path = Sources/hang.swift; sourceTree = "<group>"; };
+		D9809E72EB7D02EF0C1B11F3C209AD5F /* NSTask+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSTask+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSTask+AnyPromise.h"; sourceTree = "<group>"; };
+		D9C692C08213B8DB7387F7930D1365D4 /* BigInt-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "BigInt-dummy.m"; sourceTree = "<group>"; };
+		DD812908B6A8A5739F6E827AD436419B /* scratch_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scratch_impl.h; path = secp256k1_ios/src/scratch_impl.h; sourceTree = "<group>"; };
+		DDE1AD5054A208E4D3DB80B6C9F6916F /* AES.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.swift; path = Sources/CryptoSwift/AES.swift; sourceTree = "<group>"; };
+		DEA833EC1FB428657D0AFCA543D5BD48 /* scalar_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_impl.h; path = secp256k1_ios/src/scalar_impl.h; sourceTree = "<group>"; };
+		DFD052C962A755E481A48E56C9C09C6D /* PlainKeystore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlainKeystore.swift; path = web3swift/KeystoreManager/Classes/PlainKeystore.swift; sourceTree = "<group>"; };
+		E076F4231256E2BD592009B01EAB1489 /* Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptors.swift; path = Sources/CryptoSwift/Cryptors.swift; sourceTree = "<group>"; };
+		E089341E2F3DB80083CC5A32964F8E67 /* Square Root.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Square Root.swift"; path = "sources/Square Root.swift"; sourceTree = "<group>"; };
+		E0B177EA78A9BB9FAC15ADA59CB21E85 /* QRCodeReaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderView.swift; path = Sources/QRCodeReaderView.swift; sourceTree = "<group>"; };
+		E10FEED15925304FB7969ECED0F6F76E /* NSURLSession+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLSession+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSURLSession+AnyPromise.m"; sourceTree = "<group>"; };
+		E13BDB16C6FC7A33FA7D98F0EB669D59 /* SipHash.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SipHash.xcconfig; sourceTree = "<group>"; };
+		E147C791AC66BEF59781D15B1BBA68F6 /* secp256k1.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1.h; path = secp256k1_ios/include/secp256k1.h; sourceTree = "<group>"; };
+		E1E916781CA2BA06FB627485A88EFB61 /* Promise+Web3+Eth+SendRawTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+SendRawTransaction.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+SendRawTransaction.swift"; sourceTree = "<group>"; };
 		E1E917490C4838EEA38C4DFB3D31C25B /* Pods-DiveLane.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-DiveLane.debug.xcconfig"; sourceTree = "<group>"; };
-		E1EC6F414C91B379A64B34DAFBB3B3C9 /* HMAC+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HMAC+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/HMAC+Foundation.swift"; sourceTree = "<group>"; };
-		E225FF94575A6EAD117CBAF7BDCE9804 /* String+FoundationExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+FoundationExtension.swift"; path = "Sources/CryptoSwift/Foundation/String+FoundationExtension.swift"; sourceTree = "<group>"; };
-		E25B56E6AB08ACA0EE1CC7ABCA0292C7 /* race.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = race.swift; path = Sources/race.swift; sourceTree = "<group>"; };
-		E2F42182F81F1407C3DC7D5771E3459A /* PlainKeystore+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PlainKeystore+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/PlainKeystore+ObjC.swift"; sourceTree = "<group>"; };
-		E35D3B343A717FCDB8D4F958E8312BED /* Promise+Web3+Eth+GetBlockByNumber.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+GetBlockByNumber.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+GetBlockByNumber.swift"; sourceTree = "<group>"; };
-		E4ACD9A5E6A4EF9A218662A89A9E5D6A /* Promise+Web3+Eth+EstimateGas.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+EstimateGas.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+EstimateGas.swift"; sourceTree = "<group>"; };
+		E25B12E92E17375D241B10885F86F090 /* when.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = when.swift; path = Sources/when.swift; sourceTree = "<group>"; };
+		E2DE5E21F680A68C6578671B653D71B8 /* UInt8+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt8+Extension.swift"; path = "Sources/CryptoSwift/UInt8+Extension.swift"; sourceTree = "<group>"; };
+		E3BD777C11653A6C3DAA29269D27CEAC /* num_gmp_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_gmp_impl.h; path = secp256k1_ios/src/num_gmp_impl.h; sourceTree = "<group>"; };
+		E42CE64D280A804FDEC24FC205D78FED /* RandomUInt64.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RandomUInt64.swift; path = SipHash/RandomUInt64.swift; sourceTree = "<group>"; };
+		E49B215782D27272CEBB1CCE548EB490 /* Prime Test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Prime Test.swift"; path = "sources/Prime Test.swift"; sourceTree = "<group>"; };
 		E4D427D05CB39AF8FCE911FFC2C502CD /* Pods-DiveLane-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-DiveLane-acknowledgements.plist"; sourceTree = "<group>"; };
-		E539160B76CACFD6BA902BA856B30B06 /* Web3+Personal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Personal.swift"; path = "web3swift/Web3/Classes/Web3+Personal.swift"; sourceTree = "<group>"; };
-		E73CBF28A681EF4CB1AC90E2E10A0E26 /* GCD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GCD.swift; path = sources/GCD.swift; sourceTree = "<group>"; };
-		E77FD6D23CC86CB4BDE310436BABA615 /* SipHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SipHash.framework; path = SipHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E92AE203A4F44CDC83748EE2EFD101CF /* hash_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash_impl.h; path = secp256k1_ios/src/hash_impl.h; sourceTree = "<group>"; };
-		E99222AE65965EACC01E443FD9F22658 /* Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = Sources/CryptoSwift/Utils.swift; sourceTree = "<group>"; };
+		E59CC11F6ABC89EB9FA27553CAACD3C8 /* NSNotificationCenter+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.m"; sourceTree = "<group>"; };
+		E5A17FFD11532E99A0E9F025F03D166F /* NSURLSession+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSURLSession+Promise.swift"; path = "Extensions/Foundation/Sources/NSURLSession+Promise.swift"; sourceTree = "<group>"; };
+		E62B49C2DEA24C2E79E33B758AFA3173 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E713368D9AFBF25CF62922ABCCA8103F /* group.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = group.h; path = secp256k1_ios/src/group.h; sourceTree = "<group>"; };
+		E7D304295737E8DA2F6371A63E7DD0BD /* num_gmp.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_gmp.h; path = secp256k1_ios/src/num_gmp.h; sourceTree = "<group>"; };
+		E87751B2477DD5A23B5B37B8F2C022CB /* AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AnyPromise.m; path = Sources/AnyPromise.m; sourceTree = "<group>"; };
+		E899A2A35BBA0421324C952507C42392 /* CLSReport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLSReport.h; path = iOS/Crashlytics.framework/Headers/CLSReport.h; sourceTree = "<group>"; };
+		E96BEA8AB7CDEBF6D2FFB21A021A7E8A /* Generics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generics.swift; path = Sources/CryptoSwift/Generics.swift; sourceTree = "<group>"; };
 		EA0F4E77033149DA43DFC65423737135 /* Pods-DiveLane-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-DiveLane-acknowledgements.markdown"; sourceTree = "<group>"; };
-		EA37580FEA73153CDB7822F775F2AD8E /* field_5x52_asm_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_asm_impl.h; path = secp256k1_ios/src/field_5x52_asm_impl.h; sourceTree = "<group>"; };
-		EA3A83C2569B2AEEA18325963C025108 /* NSObject+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSObject+Promise.swift"; path = "Extensions/Foundation/Sources/NSObject+Promise.swift"; sourceTree = "<group>"; };
-		EA8CCF59177FA9414B4E01275FA4B5B5 /* NativeTypesEncoding+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NativeTypesEncoding+Extensions.swift"; path = "web3swift/Convenience/Classes/NativeTypesEncoding+Extensions.swift"; sourceTree = "<group>"; };
-		EAAB7DFE95F896DE6A26D8D73762B632 /* KeystoreManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeystoreManager.swift; path = web3swift/KeystoreManager/Classes/KeystoreManager.swift; sourceTree = "<group>"; };
-		EAADA0F39A44626A22386624E9CA132A /* AnyError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyError.swift; path = Result/AnyError.swift; sourceTree = "<group>"; };
-		EAD2BAFEA6D37F1FA154D73188D93633 /* QRCodeReaderViewContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRCodeReaderViewContainer.swift; path = Sources/QRCodeReaderViewContainer.swift; sourceTree = "<group>"; };
-		EB94837CEC92402155A27E8CB6AAC010 /* libsecp256k1-config.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "libsecp256k1-config.h"; path = "secp256k1_ios/libsecp256k1-config.h"; sourceTree = "<group>"; };
-		EBC92B4AF7864EC6077ECBDD382F325C /* Pods_DiveLane.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_DiveLane.framework; path = "Pods-DiveLane.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		EBE72EDE01F89A09C540AE649E97C3C9 /* Updatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Updatable.swift; path = Sources/CryptoSwift/Updatable.swift; sourceTree = "<group>"; };
-		EC1CF885E556C543E884514C774065EA /* Result.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Result.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		EC30CA471E3875FDC01611FACEBDEC26 /* UIViewController+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+AnyPromise.h"; path = "Extensions/UIKit/Sources/UIViewController+AnyPromise.h"; sourceTree = "<group>"; };
-		EC6FCDEC38554B2B6C697FE4E71B357F /* AES.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.swift; path = Sources/CryptoSwift/AES.swift; sourceTree = "<group>"; };
-		EC8289F3C94B21C93376E2FB4DE31BFF /* UInt32+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt32+Extension.swift"; path = "Sources/CryptoSwift/UInt32+Extension.swift"; sourceTree = "<group>"; };
-		EE657AF6DA9389F135A039CFFC4A748F /* ResultProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResultProtocol.swift; path = Result/ResultProtocol.swift; sourceTree = "<group>"; };
-		EEEB93F035012C9898D5A7532A30390A /* secp256k1_ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = secp256k1_ios.xcconfig; sourceTree = "<group>"; };
-		EF3C5B8DD6E4101232857EDCFB29BA3B /* EventFiltering.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventFiltering.swift; path = web3swift/Contract/Classes/EventFiltering.swift; sourceTree = "<group>"; };
-		F1F1DE46A800C6C6ACF22F28AC4A9E55 /* BigInt.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = BigInt.xcconfig; sourceTree = "<group>"; };
-		F2F218A5404769FBD65244D21C4C1632 /* Resolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Resolver.swift; path = Sources/Resolver.swift; sourceTree = "<group>"; };
-		F3E8408039DE8DAE9AF68CB2494CA790 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F41A3CD9569B48AC734B519796E3C826 /* ecdsa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdsa.h; path = secp256k1_ios/src/ecdsa.h; sourceTree = "<group>"; };
-		F45F460F0DE60D0DEC59CFA40E7BB519 /* EthereumAddress+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "EthereumAddress+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/EthereumAddress+ObjC.swift"; sourceTree = "<group>"; };
-		F4FBA9F9CF2F485F33DCE5586671C9E7 /* Deprecations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deprecations.swift; path = Sources/Deprecations.swift; sourceTree = "<group>"; };
-		F50E53C4909EEB420176F673A114DC38 /* NSURLSession+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLSession+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSURLSession+AnyPromise.m"; sourceTree = "<group>"; };
-		F570D9AA2AB57C2A5EBF29E6082D9732 /* OFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OFB.swift; path = Sources/CryptoSwift/BlockMode/OFB.swift; sourceTree = "<group>"; };
-		F58BDDA276A7BE795A0ABE5B5DB9B775 /* scalar_4x64.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_4x64.h; path = secp256k1_ios/src/scalar_4x64.h; sourceTree = "<group>"; };
-		F59FCF5E84197D2A24E0AAEA2AC41BAB /* CBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBC.swift; path = Sources/CryptoSwift/BlockMode/CBC.swift; sourceTree = "<group>"; };
-		F61B9122E3779351D03DFD6CAF5B0D6E /* RLP.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RLP.swift; path = web3swift/Utils/Classes/RLP.swift; sourceTree = "<group>"; };
-		F6CB1D681610799419772BC3B32139EC /* ContractProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContractProtocol.swift; path = web3swift/Contract/Classes/ContractProtocol.swift; sourceTree = "<group>"; };
-		F731FE642E29D942A2602E615A503A8D /* ChaCha20+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ChaCha20+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/ChaCha20+Foundation.swift"; sourceTree = "<group>"; };
-		F823FDD38A4551CF9D48F30E8B333E78 /* Web3+TransactionIntermediate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+TransactionIntermediate.swift"; path = "web3swift/Web3/Classes/Web3+TransactionIntermediate.swift"; sourceTree = "<group>"; };
-		FBBA16F895F2F9128478336664AD83DB /* Cryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptor.swift; path = Sources/CryptoSwift/Cryptor.swift; sourceTree = "<group>"; };
-		FC852AFAFDAF21F5CDC00B08C2C9A229 /* ecmult_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_impl.h; path = secp256k1_ios/src/ecmult_impl.h; sourceTree = "<group>"; };
-		FCA59745B42B4791921F39555C5670F4 /* Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptors.swift; path = Sources/CryptoSwift/Cryptors.swift; sourceTree = "<group>"; };
-		FD59E5D486F37BD5BE6262B1D48A811D /* util.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = util.h; path = secp256k1_ios/src/util.h; sourceTree = "<group>"; };
-		FE43D491122858F762CB98C49FA1B1B2 /* lax_der_privatekey_parsing.c */ = {isa = PBXFileReference; includeInIndex = 1; name = lax_der_privatekey_parsing.c; path = secp256k1_ios/contrib/lax_der_privatekey_parsing.c; sourceTree = "<group>"; };
-		FFEA9371FBA0B1B3B64B73679B9ED051 /* BlockMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockMode.swift; path = Sources/CryptoSwift/BlockMode/BlockMode.swift; sourceTree = "<group>"; };
+		EA2334F5B6CC246D4C90FF86CF55D594 /* scrypt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scrypt.h; path = scrypt/scrypt.h; sourceTree = "<group>"; };
+		EAB070DE5C274B1063284536E06DF63A /* BufferStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BufferStorage.swift; path = scrypt/scrypt/BufferStorage.swift; sourceTree = "<group>"; };
+		EAC3394F8A3EE59C59A9733F786B1306 /* secp256k1_ios-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "secp256k1_ios-umbrella.h"; sourceTree = "<group>"; };
+		ED02205DB9E2AA26F8B91AF593BC46D9 /* Base58.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Base58.swift; path = web3swift/Convenience/Classes/Base58.swift; sourceTree = "<group>"; };
+		ED8175B9D465CE6E38ABB43A417B0416 /* Exponentiation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Exponentiation.swift; path = sources/Exponentiation.swift; sourceTree = "<group>"; };
+		EDA911506B7BC5F109F11E624B3B58A9 /* UIView+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIView+Promise.swift"; path = "Extensions/UIKit/Sources/UIView+Promise.swift"; sourceTree = "<group>"; };
+		EDCF6AEDC0537776CE0D24F9F130750D /* BlockDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockDecryptor.swift; path = Sources/CryptoSwift/BlockDecryptor.swift; sourceTree = "<group>"; };
+		EDD7A4E497D99E6792618A7AC28151C0 /* Validation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Validation.swift; path = Source/Validation.swift; sourceTree = "<group>"; };
+		EDFA1AE34EF824D45F5201833B299CFD /* PKCS5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS5.swift; path = Sources/CryptoSwift/PKCS/PKCS5.swift; sourceTree = "<group>"; };
+		F0C72BB8D51ACBF1419C13135AFA27E2 /* Promise+Web3+Eth+SendTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Web3+Eth+SendTransaction.swift"; path = "web3swift/Promises/Classes/Promise+Web3+Eth+SendTransaction.swift"; sourceTree = "<group>"; };
+		F1B153ADEBC0499C2F1A09B7CCF1CFED /* BigUInt+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BigUInt+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/BigUInt+ObjC.swift"; sourceTree = "<group>"; };
+		F2A3ADDF7A53DF282AE4E6A160C657D2 /* AEADChaCha20Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEADChaCha20Poly1305.swift; path = Sources/CryptoSwift/AEAD/AEADChaCha20Poly1305.swift; sourceTree = "<group>"; };
+		F3AA68A9D6621F4FA5B468BAFEA1D19A /* ToggleTorchButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToggleTorchButton.swift; path = Sources/ToggleTorchButton.swift; sourceTree = "<group>"; };
+		F4760D4934E5BC86AFC5A4E4A63E99D4 /* Bitwise Ops.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bitwise Ops.swift"; path = "sources/Bitwise Ops.swift"; sourceTree = "<group>"; };
+		F4ABFDA4F6189C60A794986F555A9C0F /* Hashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Hashable.swift; path = sources/Hashable.swift; sourceTree = "<group>"; };
+		F5E8202B9346F8FC67DC758394515FF8 /* race.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = race.swift; path = Sources/race.swift; sourceTree = "<group>"; };
+		F69FE100A8E9CB0B6B86E4A44DFF1824 /* SHA1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA1.swift; path = Sources/CryptoSwift/SHA1.swift; sourceTree = "<group>"; };
+		F6D05D2A1BBDC61553D83CB65BD52980 /* Web3+Instance+ObjC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Instance+ObjC.swift"; path = "web3swift/ObjectiveCbridge/Classes/Web3+Instance+ObjC.swift"; sourceTree = "<group>"; };
+		F8B484180C55627FAAA803F7EE2DCEAB /* NSNotificationCenter+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSNotificationCenter+Promise.swift"; path = "Extensions/Foundation/Sources/NSNotificationCenter+Promise.swift"; sourceTree = "<group>"; };
+		F9C3B59AB29207F987669AFD77BA598F /* Web3+Eth.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Eth.swift"; path = "web3swift/Web3/Classes/Web3+Eth.swift"; sourceTree = "<group>"; };
+		FA9A2A62C6BE578858DAF7399D3F4241 /* Division.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Division.swift; path = sources/Division.swift; sourceTree = "<group>"; };
+		FAAD058A045B19FB88C786D6B60224BE /* ecmult_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_impl.h; path = secp256k1_ios/src/ecmult_impl.h; sourceTree = "<group>"; };
+		FC491B89F0720A366015E66C7CC50C8D /* Web3+Personal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Personal.swift"; path = "web3swift/Web3/Classes/Web3+Personal.swift"; sourceTree = "<group>"; };
+		FCC646ABA7678EACF23DC0CA54F3A551 /* CryptoSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CryptoSwift.modulemap; sourceTree = "<group>"; };
+		FD5ADDF19D753AE50759F2928852E35C /* Web3+Options.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+Options.swift"; path = "web3swift/Web3/Classes/Web3+Options.swift"; sourceTree = "<group>"; };
+		FDF1750F92AA20B76F5A46748B45B385 /* Rabbit+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Rabbit+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Rabbit+Foundation.swift"; sourceTree = "<group>"; };
+		FF465D10A7EA9D71A99A1C40B58BE3A5 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/Error.swift; sourceTree = "<group>"; };
+		FF9A701DEBB66A53F6A279814BAB217A /* Web3+EventParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+EventParser.swift"; path = "web3swift/Web3/Classes/Web3+EventParser.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -896,28 +947,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		36A4523547494987F793873748A028A7 /* Frameworks */ = {
+		6E8AF668A2161F7D6F680F721DB65D2D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E38307483197EA2E6C7955C6FD1997DB /* BigInt.framework in Frameworks */,
-				6571B3D9C8C50DAA1B1D90169F930B6E /* CoreImage.framework in Frameworks */,
-				9E93BE33E88E3B32CAFCCC9737459B5F /* CryptoSwift.framework in Frameworks */,
-				78384A7DC28D6977EA0C8357325103A1 /* Foundation.framework in Frameworks */,
-				91DD917708287C75B4AB4B8352BB833B /* PromiseKit.framework in Frameworks */,
-				C466D2734F3AE12E8DEA1D0F6AC37CAE /* Result.framework in Frameworks */,
-				DB09CB5BA015B9F340ECF790D20AB58C /* scrypt.framework in Frameworks */,
-				D331038D5B32F2A318ED1E288AEECFE4 /* secp256k1_ios.framework in Frameworks */,
-				BF434DC19FC26804E361545DA07AABB1 /* SipHash.framework in Frameworks */,
+				D8EC5B74B9B5DC842F4179D19E6DE6D4 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4ADBB089E0AEA24F21FB76041EFE327A /* Frameworks */ = {
+		70BE950118F53DC9E9F48703255B415A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8E1E2E8AF7F530A2BD21A0F324B0CE6F /* AVFoundation.framework in Frameworks */,
-				6B4B70B7430A196D71A62DCB5EFBB3D2 /* Foundation.framework in Frameworks */,
+				7618195AD4D64CB705BD0F5A1F935C45 /* BigInt.framework in Frameworks */,
+				2B1A7912BC4619FA895DA18E9947BB4B /* CoreImage.framework in Frameworks */,
+				086443BE824CBF220F1E1493106DBFB2 /* CryptoSwift.framework in Frameworks */,
+				424D08F2723FA1787938D86A1BC76120 /* Foundation.framework in Frameworks */,
+				894FD1032DA7DA0E413336B69FC86B68 /* PromiseKit.framework in Frameworks */,
+				E8AF3C9FA340B6C84D3849E32F10BE92 /* Result.framework in Frameworks */,
+				5CFD2A9370693702B6367CD3E9C8C4F3 /* scrypt.framework in Frameworks */,
+				4208A2E92B8AE0BD48D0E2802467D954 /* secp256k1_ios.framework in Frameworks */,
+				B66A130B772B7A08CD6EE4C1EC4121EA /* SipHash.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		741B718A2BC8A59FFCD8B8927E40EE78 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				18FA405787153F24474D350A8F06B31A /* AVFoundation.framework in Frameworks */,
+				D8CBB683C91FFC751090C3C9340EEA97 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -929,36 +988,37 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8EEA89C830F2D7EA4283377BE59AD0A1 /* Frameworks */ = {
+		9E8EA1BE2E6CF96CEEF5C6B1F8A0444F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				56C1BDEC993C1EB8D74B7D0D83D0A0D5 /* Foundation.framework in Frameworks */,
+				41D4B2B2836194F9274B2BAAF90A047B /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		96BDDB24C568149F0A1CC93AD0E4BA5C /* Frameworks */ = {
+		AB4FAA8A9B5CF38AC2D4F4BD4B9EA1B8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FC7516970C002B119C35BDD3FD2092CC /* Foundation.framework in Frameworks */,
+				19205E9932BE7576D08EA1325104EAAD /* CryptoSwift.framework in Frameworks */,
+				05A846483F7B82BCDD0A009DF3B2F72D /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		98EF3A34897D9731D9C0CD721BF3EB16 /* Frameworks */ = {
+		B05A977C6F0AAB1146FC571FFA07EBEB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A2D9742D1A9BF2A257A9B380EDD3FA9A /* Foundation.framework in Frameworks */,
+				9AACC7433B699B5CD9551CC03F97CBFC /* Foundation.framework in Frameworks */,
+				875A8728A87183C01F95D896CB3CB41E /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AF214B39E3CD33D63E2CD18C114AEEDC /* Frameworks */ = {
+		C465C6DA993B47AA16B0450E5E6C27DC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4BD57F8AF66C371F889AB05F16C1CE8C /* Foundation.framework in Frameworks */,
-				C071946D94F30A19A067A2F37B699826 /* UIKit.framework in Frameworks */,
+				E68622C1CC4BA4F54ACCCEBD134A648D /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -970,133 +1030,221 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EC82EB0F5782563E9E7A2047AD5605F7 /* Frameworks */ = {
+		FABDC971425BC3040587EB18F2DFC8A0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E1A425C63B72CE7036F945291C1ACBCB /* CryptoSwift.framework in Frameworks */,
-				E058CDF8AC170914C28E1A9F88FFE479 /* Foundation.framework in Frameworks */,
+				1EB5C7E4EDF2B79FBAE67F37FCB6BDD3 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		12F95F5CEAA1631029F458B049FD665D /* UIKit */ = {
+		085509A7A9D33257C468D1B2099F3C81 /* SipHash */ = {
 			isa = PBXGroup;
 			children = (
-				D6C1DEAB322EB0D48D628D067BA01A90 /* PMKUIKit.h */,
-				BA78A7BEFA2005B4F4984EB44F936189 /* UIView+AnyPromise.h */,
-				B30A1A7519934D9C2130711A3D73EA88 /* UIView+AnyPromise.m */,
-				627075D1CD3CC2CD9BAC5F5A59164588 /* UIView+Promise.swift */,
-				EC30CA471E3875FDC01611FACEBDEC26 /* UIViewController+AnyPromise.h */,
-				DFF18856CBCE4C2A15E7E8D5634BE7EF /* UIViewController+AnyPromise.m */,
-				7BFEF37D5BF463C9959B0164D3C71435 /* UIViewPropertyAnimator+Promise.swift */,
+				9E2290B9A60E8498F813AE6510A42F13 /* Primitive Types.swift */,
+				E42CE64D280A804FDEC24FC205D78FED /* RandomUInt64.swift */,
+				754C8F70937EC24C697F6128DEA15C39 /* SipHashable.swift */,
+				6C4AEDF255D6A629E1A280179E5A7A5A /* SipHasher.swift */,
+				25E92C1294907F6FDD4CE07C511707CA /* Support Files */,
 			);
-			name = UIKit;
+			name = SipHash;
+			path = SipHash;
 			sourceTree = "<group>";
 		};
-		33F04C7CA8189DFB48F0A393689DDE78 /* Support Files */ = {
+		0A76D811D50CB6D8736790335E3893ED /* web3swift */ = {
 			isa = PBXGroup;
 			children = (
-				30F9C16F37B00042E1A471CF0F624E33 /* BigInt.modulemap */,
-				F1F1DE46A800C6C6ACF22F28AC4A9E55 /* BigInt.xcconfig */,
-				116491EB3DDBCFC5D26AB838F91A61C4 /* BigInt-dummy.m */,
-				07A9C8F6F2EE664C5C5D021E03EA4A01 /* BigInt-prefix.pch */,
-				7480746568231EDF17603715FE554263 /* BigInt-umbrella.h */,
-				3860346F961EA6FD2278D645EE921AED /* Info.plist */,
+				7E196127E64DF41026ECBAD011870259 /* ABIv2.swift */,
+				69A8581A98F919BDD990E2151B4CD5DA /* ABIv2Decoding.swift */,
+				4AD300E1DE0EC70FDA3B58AFBF0BDB0D /* ABIv2Elements.swift */,
+				6D8E7890E553410A109389CB2B47FAFB /* ABIv2Encoding.swift */,
+				C227389A3CE55B031095EF269734DD76 /* ABIv2ParameterTypes.swift */,
+				477123AC338560B8480BAF4EB5D7988E /* ABIv2Parsing.swift */,
+				28B0D548D90EED6693E65BFE9FB8FB3F /* ABIv2TypeParser.swift */,
+				BF4CCC3CD81989D23B696E7053A33F40 /* AbstractKeystore.swift */,
+				418047EC2D5B05083EEFC267F36DFF2F /* Array+Extension.swift */,
+				ED02205DB9E2AA26F8B91AF593BC46D9 /* Base58.swift */,
+				F1B153ADEBC0499C2F1A09B7CCF1CFED /* BigUInt+ObjC.swift */,
+				43C1B47B887904819BBE309C8F894E28 /* BIP32HDNode.swift */,
+				27015053B3711311638314C3A7F0E3A3 /* BIP32Keystore.swift */,
+				200F222DE33017888FF05655EE1C54CC /* BIP32KeystoreJSONStructure.swift */,
+				5C2BB327C9C1AAFC7DE617C91C6D1CDA /* BIP39.swift */,
+				3F41DA8948731CD42489BE7B783574EF /* BIP39+WordLists.swift */,
+				CCEB6BCBCF2FA9650F28438EF13B70FA /* BlockExplorer.swift */,
+				09530693B905CFC7A6FDC129C4FF9BCC /* BlockExplorer+GetTransactionHistory.swift */,
+				4BF6CEF45BF5ADAC2C2EE5B3F4563116 /* BloomFilter.swift */,
+				CF458B3B854F09D3F06D88AC6EAAC0EE /* ComparisonExtensions.swift */,
+				ABE4C1AA983DDFB7CFBD319A1A3354F5 /* ContractABIv2.swift */,
+				6EE955DAE69C8E70BC0EFC70000E07FC /* ContractProtocol.swift */,
+				6A302CC286398A108E7231D64743135C /* CryptoExtensions.swift */,
+				6017DE25135638C3828C30F112AB8975 /* Data+Extension.swift */,
+				1C9AFAD6A9F4E84A058F5A53D7377E0A /* Dictionary+Extension.swift */,
+				0BA82B8AB03FC2F59B88A0669833A7ED /* EIP67Code.swift */,
+				8CEDC0A46453491F47C267BB99CA85A7 /* EIP681.swift */,
+				706B73F36D2AA0D1FFC213721F48B3A4 /* ENS.swift */,
+				3D040FBD626100B2AD97DA4094AC0FBD /* EthereumAddress.swift */,
+				6B623A2B8697B4678F96B21A6B722FC6 /* EthereumAddress+ObjC.swift */,
+				A6A0705AACC34D9047350BA409367FD3 /* EthereumFilterEncodingExtensions.swift */,
+				68C20F6218D2D54CC76539F69C082B4E /* EthereumKeystoreV3.swift */,
+				5204B9F811E9F85B65EACB4BCE2A0E40 /* EthereumTransaction.swift */,
+				C2A288328F7FF4DE93CFF3FDDDE072D3 /* EventFiltering.swift */,
+				028415A0C2513E40239599F74C61D39D /* IBAN.swift */,
+				3153BA12BB5A92893507F8F2B04439A0 /* KeystoreManager.swift */,
+				41366DDC06EA73CDFBD8E1CA9C774F03 /* KeystoreManager+ObjC.swift */,
+				C3524EB86E47609DFFFA6E121A73E5CD /* KeystoreV3JSONStructure.swift */,
+				41AEA2DF1157620919DECEC2873190EE /* LibSecp256k1Extension.swift */,
+				17A7144477B01A7D9D160DFD8C0A8C42 /* NameHash.swift */,
+				894917C6A99D4E63593BC49A81275AA2 /* NativeTypesEncoding+Extensions.swift */,
+				1F0B56AB8D88FE4DE6C230ACD3C39D54 /* NSRegularExpressionExtension.swift */,
+				DFD052C962A755E481A48E56C9C09C6D /* PlainKeystore.swift */,
+				CBB6967D78BDD324F6C6F7152A13DCF3 /* PlainKeystore+ObjC.swift */,
+				A81BD1624603AFA149D3E661A842C8CE /* Promise+Batching.swift */,
+				D05C3368C5FD7ECC5190CD02861FC492 /* Promise+HttpProvider.swift */,
+				0B393D9B7755F5DE1F1A4B16B75B34E7 /* Promise+Web3+Contract+GetIndexedEvents.swift */,
+				BC5BEB238DEA66EAD3E72BCD58B993D0 /* Promise+Web3+Eth+Call.swift */,
+				6E5F4741DEF41B9DE628EEF93D72CB87 /* Promise+Web3+Eth+EstimateGas.swift */,
+				ABD42F09517187F64B86B1D785855A84 /* Promise+Web3+Eth+GetAccounts.swift */,
+				53462C3C917ABB5047BB31683E29A3C5 /* Promise+Web3+Eth+GetBalance.swift */,
+				229BC0CAF8AD47BBB98F8626C188F13D /* Promise+Web3+Eth+GetBlockByHash.swift */,
+				98E41E2D43AA4B11B56B0F45BBAC5738 /* Promise+Web3+Eth+GetBlockByNumber.swift */,
+				B774B455364008941BBBD9AE3C63743A /* Promise+Web3+Eth+GetBlockNumber.swift */,
+				5CC0D7B391633DBB114E1F27A93BA165 /* Promise+Web3+Eth+GetGasPrice.swift */,
+				6E135D280E58286565605E0EE6CBA253 /* Promise+Web3+Eth+GetTransactionCount.swift */,
+				5BE1814071187E6505D8CCDF37C0FBD7 /* Promise+Web3+Eth+GetTransactionDetails.swift */,
+				2CCBD96EC145E10468934052206A64E8 /* Promise+Web3+Eth+GetTransactionReceipt.swift */,
+				E1E916781CA2BA06FB627485A88EFB61 /* Promise+Web3+Eth+SendRawTransaction.swift */,
+				F0C72BB8D51ACBF1419C13135AFA27E2 /* Promise+Web3+Eth+SendTransaction.swift */,
+				1BDBFB5794940426BCD9BC3BEF8C03AB /* Promise+Web3+Intermediate+Send.swift */,
+				A9361D2F2F5838E6646F06E68392D728 /* Promise+Web3+Personal+Sign.swift */,
+				07523400160228A9177C0F89B5A538FF /* Promise+Web3+Personal+UnlockAccount.swift */,
+				182E59CA843B29EDC922D24FCE451B57 /* RIPEMD160+StackOveflow.swift */,
+				45748A876870FC089152EF8FD81E9A75 /* RLP.swift */,
+				41102EF377C8CDAC35545F9584C7C182 /* String+Extension.swift */,
+				24390439BA0255CEDE98DD9AE1B0C0BE /* TransactionSigner.swift */,
+				D343411628B4DF169F56E7AFE870A582 /* Web3.swift */,
+				6EC6C34F1EB41D1A5C278D510066904B /* Web3+BrowserFunctions.swift */,
+				AB6FA2B4E48BAAF86E40E8B34BCCF974 /* Web3+Contract.swift */,
+				A523F91DD68A69492E50FEE51152D552 /* Web3+ERC20.swift */,
+				F9C3B59AB29207F987669AFD77BA598F /* Web3+Eth.swift */,
+				836ED2ADDCB705E25214F2432D3EDE48 /* Web3+Eth+ObjC.swift */,
+				FF9A701DEBB66A53F6A279814BAB217A /* Web3+EventParser.swift */,
+				31F4C8B0EAA83CF8E5F07AFBF5FD6281 /* Web3+HttpProvider.swift */,
+				49FF436EC9B609E571B4778D2AF17F45 /* Web3+HttpProvider+ObjC.swift */,
+				BA3019DE0415EB42DFAFD80C013444D7 /* Web3+Infura.swift */,
+				99978E9C44BDF8277225A7AD3CD7D0E6 /* Web3+Instance.swift */,
+				F6D05D2A1BBDC61553D83CB65BD52980 /* Web3+Instance+ObjC.swift */,
+				455F2819B3A0EA97496C5877D0E29378 /* Web3+JSONRPC.swift */,
+				3A9E7E3492F16CF045775D93AEF49A94 /* Web3+Methods.swift */,
+				01852DFE34B287694A75EA0A355C3E5D /* Web3+ObjC.swift */,
+				FD5ADDF19D753AE50759F2928852E35C /* Web3+Options.swift */,
+				FC491B89F0720A366015E66C7CC50C8D /* Web3+Personal.swift */,
+				78100FEA5A147FDAC8E526311C18EE60 /* Web3+Protocols.swift */,
+				D3679BBFDE812DA031A88BA78BA37E13 /* Web3+Structures.swift */,
+				353695A952984817097B654FD92DDFCC /* Web3+TransactionIntermediate.swift */,
+				314780CA47604CA2ED4B735A4A3EBEBB /* Web3+Utils.swift */,
+				B124045913A60D2E6F4B128D31FB54A1 /* Web3+Wallet.swift */,
+				0F6F2F013DE7F8622027C3569BCF1A9A /* web3swift.h */,
+				168C58A5F2EE3DA843CAD4C824AA0C52 /* web3swift-Bridging-Header.h */,
+				F0F046EE1FB998A9E379C8FD1FF770B5 /* Support Files */,
+			);
+			name = web3swift;
+			path = web3swift;
+			sourceTree = "<group>";
+		};
+		0DD294729847EF2B8AD5731CFB0E53F9 /* CorePromise */ = {
+			isa = PBXGroup;
+			children = (
+				5FE7D0E9CCED9C9CE1FBEE4A5253E1F2 /* after.m */,
+				27E5CCF0E45CEB1373D954DBA4B4A322 /* after.swift */,
+				871136A970C2EE6E1F4E02424D526B91 /* AnyPromise.h */,
+				E87751B2477DD5A23B5B37B8F2C022CB /* AnyPromise.m */,
+				123708BCF6EF6B6B3CBE29C625D073FE /* AnyPromise.swift */,
+				868CA8B8525183BB82B5B7EC40669EFA /* Box.swift */,
+				16AA4804DE767546B170499C025D3872 /* Catchable.swift */,
+				329D2572A9B9E9AB32813C05710EFB65 /* Configuration.swift */,
+				A231571D3499DDA617E10EEA78857D32 /* CustomStringConvertible.swift */,
+				11AC88FC19324B1F65425A48229FA2A9 /* Deprecations.swift */,
+				35A7901737C34A9742D5B99DC7C9466E /* dispatch_promise.m */,
+				FF465D10A7EA9D71A99A1C40B58BE3A5 /* Error.swift */,
+				11C97902182015B3601CE10E1F25CE34 /* firstly.swift */,
+				0541307DD5375D347F8E968760A8B67E /* fwd.h */,
+				D38BB6B56E3E88A1D6E48D0DE5D6364D /* Guarantee.swift */,
+				7FF820BE0E9F0B29D4E6A63A9E9CA7A6 /* hang.m */,
+				D92CEF49FC2D0F46DDBF5F67D4400DD9 /* hang.swift */,
+				31DC89BD1E950F19A4B697E65EBC702B /* join.m */,
+				12B2ABBEA99EE344B066F54DC7AC1813 /* Promise.swift */,
+				4E2FFE6E982290CFF29A826A4B438822 /* PromiseKit.h */,
+				2328858BB115D2308FE8B5AFFE824C53 /* race.m */,
+				F5E8202B9346F8FC67DC758394515FF8 /* race.swift */,
+				C60D5B76E28C82511B6EF078E996882C /* Resolver.swift */,
+				A4EFCF9E0550A93DEB58F8D4FF35A5A2 /* Thenable.swift */,
+				C65CC5DD174B751E11B617617457C6AD /* when.m */,
+				E25B12E92E17375D241B10885F86F090 /* when.swift */,
+			);
+			name = CorePromise;
+			sourceTree = "<group>";
+		};
+		19480CB1024C73E32486E91584E6C941 /* Result */ = {
+			isa = PBXGroup;
+			children = (
+				5705E17A5DC8CD041A2FCB5A82346147 /* AnyError.swift */,
+				52756545CBB2AEE411B9EAC53FEE5CCB /* NoError.swift */,
+				348A903FD4E883A5C775BEDF44449057 /* Result.swift */,
+				93DBBC54280BEBF480E364971D5239C7 /* ResultProtocol.swift */,
+				9C15914AA3E89EEAC3D02D27D10F6F18 /* Support Files */,
+			);
+			name = Result;
+			path = Result;
+			sourceTree = "<group>";
+		};
+		25E92C1294907F6FDD4CE07C511707CA /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				B91C43CC342DEECF3EAD2D00DF142834 /* Info.plist */,
+				AA3DE8A50B82E65318FC3E2406D9086B /* SipHash.modulemap */,
+				E13BDB16C6FC7A33FA7D98F0EB669D59 /* SipHash.xcconfig */,
+				68D9FB9D5B9D0CDF0571383B95ABC1E4 /* SipHash-dummy.m */,
+				B8708AAEEC5CE4CC134AC9BBB41A1832 /* SipHash-prefix.pch */,
+				067A6AD52AEA1B0726AFE145CAB24931 /* SipHash-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/BigInt";
+			path = "../Target Support Files/SipHash";
 			sourceTree = "<group>";
 		};
-		3557A0BF141D1082CD3D6D324FD99EFC /* BigInt */ = {
+		28C094DCFCF0BFC0D1DE2614F9F81C3C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				D6B66623F19008617D078D938B35FA5E /* Addition.swift */,
-				AF6107660A564CA761AD2EE8C3D92E78 /* BigInt.swift */,
-				C98042B15E6438A1708C16E5D4E99EA2 /* BigUInt.swift */,
-				D5617684FF7E52B38B69C71ADE69269D /* Bitwise Ops.swift */,
-				3A79EC772E62A13DE0CD7323749B7E37 /* Codable.swift */,
-				0A182EFBD4BEB3EB8E3EAFFEBFCB4A07 /* Comparable.swift */,
-				BFC1B01C1779486510931BD394A8BDF9 /* Data Conversion.swift */,
-				72BC742DB402AF7B08A06EE403E81E34 /* Division.swift */,
-				4C0E4445536E7E006B2D0CBE3BA980AF /* Exponentiation.swift */,
-				75D2B4F401F83AED97758430F7961B31 /* Floating Point Conversion.swift */,
-				E73CBF28A681EF4CB1AC90E2E10A0E26 /* GCD.swift */,
-				04E1D36DD7AD259ED0E4D294C105AF4F /* Hashable.swift */,
-				C1FE37645FB80882CAF3C4AB67585742 /* Integer Conversion.swift */,
-				8353E7ABE22A3D8C80B5560B6C664C65 /* Multiplication.swift */,
-				D439BB66554D1352661D93A5B8DCC2CD /* Prime Test.swift */,
-				DF49644077A1B25CAA8CF54D4DBC095D /* Random.swift */,
-				454398613D40E174051C0EC0F05B4B27 /* Shifts.swift */,
-				56E2F4ABFD2C598332B26D0985CCDF9A /* Square Root.swift */,
-				2096C189F0562355E3A36E1297CE4C80 /* Strideable.swift */,
-				C1EAE8C76427A933698DEB3D56A3427A /* String Conversion.swift */,
-				4F77F20EAEAABCAC2FA77A90BC1F5DF6 /* Subtraction.swift */,
-				D38CE9424BB10682C68AC1F0EAE2F0DA /* Words and Bits.swift */,
-				33F04C7CA8189DFB48F0A393689DDE78 /* Support Files */,
-			);
-			name = BigInt;
-			path = BigInt;
-			sourceTree = "<group>";
-		};
-		3B898ADB30F3DC1B4601E26E905795F3 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				62BE12C598888D291FFB815FB310D2FD /* Crashlytics.framework */,
+				93CEC7DE4894315B947D9A24501EC842 /* Fabric.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		41FB60A9CFBCB3BD77399DDDA1B32C97 /* PromiseKit */ = {
+		4C3BA0DB2DE862FB9F6AF3BD8F298095 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				E27D4BB8774F1FD558E87CA98BF52B24 /* CorePromise */,
-				F3AA583CC93045D4ECC14095048ED46E /* Foundation */,
-				4FCA0AF1E7E7C7877344B4EDDF690D0C /* Support Files */,
-				12F95F5CEAA1631029F458B049FD665D /* UIKit */,
-			);
-			name = PromiseKit;
-			path = PromiseKit;
-			sourceTree = "<group>";
-		};
-		4FCA0AF1E7E7C7877344B4EDDF690D0C /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				40BB8429BBEE227F1F4E35C982BADDC8 /* Info.plist */,
-				38A918E70DCD31FFA1E0D528D6B6DD63 /* PromiseKit.modulemap */,
-				0602B443D4A90F45A146F9DF0317539F /* PromiseKit.xcconfig */,
-				741946BB436E10C32D32D95AA6E2C46E /* PromiseKit-dummy.m */,
-				8F4412AEA55497300EA717D896E7EDC8 /* PromiseKit-prefix.pch */,
-				75E649687609BA0B77003F631ACCAF69 /* PromiseKit-umbrella.h */,
+				AB7F45E650B4C57D8F5B9F644B28D870 /* Info.plist */,
+				19E35848F92A7606931CDF7A787E77B1 /* scrypt.modulemap */,
+				28B3CB87BCF1CA2665B162967F951CA8 /* scrypt.xcconfig */,
+				2FDAC5548CA3EB33BFEE567F190504B5 /* scrypt-dummy.m */,
+				1F2DC73E7750E340525D053AAA720356 /* scrypt-prefix.pch */,
+				C9AC7A31D4825C72086072BC767F4C1D /* scrypt-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/PromiseKit";
+			path = "../Target Support Files/scrypt";
 			sourceTree = "<group>";
 		};
-		525538D21843EE8522B7C2F626C4BB91 /* Frameworks */ = {
+		4C8A6B179AA4E76C202BBCBA889E8504 /* Fabric */ = {
 			isa = PBXGroup;
 			children = (
-				4F58337C98259FDA10B250EDFD6CDBB7 /* Fabric.framework */,
+				48767CE0F05CCE5D2C8AF7EFB32549FF /* FABAttributes.h */,
+				5EF031BCCC36CFE433CDA5CE06B9E32F /* Fabric.h */,
+				28C094DCFCF0BFC0D1DE2614F9F81C3C /* Frameworks */,
 			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		561640991975BB85C4192B481BEE4107 /* Crashlytics */ = {
-			isa = PBXGroup;
-			children = (
-				B96D5CFB4AFC33326C3B9877B1669AE0 /* ANSCompatibility.h */,
-				46F9736F1CED5682322FB9397E8715D9 /* Answers.h */,
-				069B40FE78D0D96C7AFCFA1737F41470 /* CLSAttributes.h */,
-				BEB195D191088CD6E9D8714727A72B1C /* CLSLogging.h */,
-				CA403788D75396DDF796912329E2CF6B /* CLSReport.h */,
-				8FA5CD8CA42EE780A45DA782A0A7556F /* CLSStackFrame.h */,
-				432A2035EF1704290FD9017242EDCACB /* Crashlytics.h */,
-				3B898ADB30F3DC1B4601E26E905795F3 /* Frameworks */,
-			);
-			name = Crashlytics;
-			path = Crashlytics;
+			name = Fabric;
+			path = Fabric;
 			sourceTree = "<group>";
 		};
 		6141D00C50F788189760EAB700C0BF7B /* Targets Support Files */ = {
@@ -1107,35 +1255,157 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		61AF252354DA383FB4D5BFF297649F01 /* Pods */ = {
+		61585239C97BA3866332989DA49840CF /* secp256k1_ios */ = {
 			isa = PBXGroup;
 			children = (
-				3557A0BF141D1082CD3D6D324FD99EFC /* BigInt */,
-				561640991975BB85C4192B481BEE4107 /* Crashlytics */,
-				AB5B650DE62CB5FBB2B7901F107B4CC7 /* CryptoSwift */,
-				AD8EB3600FFEBC42F621C6215A9EA5BF /* Fabric */,
-				41FB60A9CFBCB3BD77399DDDA1B32C97 /* PromiseKit */,
-				FC902BF2403FD3379E3A4FAC7C527576 /* QRCodeReader.swift */,
-				CE4A66EDA1C5ADA494575225F588CC14 /* Result */,
-				C49685B3B3104A8AF4B1FCDEC161092B /* scrypt */,
-				FD5B625A6D244DDB4F700EE90D246A7E /* secp256k1_ios */,
-				7D7949CA83804BC8CA5E2ABDD29856E1 /* SipHash */,
-				8E713FDAB949489E2BCE0F6B1AD10022 /* web3swift */,
+				C787950D811A87FB57E6DE5D3B1A8DE5 /* basic-config.h */,
+				6FDDD749C3760952A98C4202E2CD7F99 /* ecdsa.h */,
+				A88E1E37AA32CDBC72132AC7BDD7FE7B /* ecdsa_impl.h */,
+				4745C274EF8239883C005C2A06EA7255 /* eckey.h */,
+				8882CE2764E4BE56DF60C9E9657CA9F3 /* eckey_impl.h */,
+				256FDD8691B426343D2053D0BE86C4B1 /* ecmult.h */,
+				46FBB4349EC969ED97E0E4CE07FA1333 /* ecmult_const.h */,
+				8FD8FE5B63CA9FD72BE519AF59F5E1B9 /* ecmult_const_impl.h */,
+				1B3FA166F72D9546A2CBA57933AD2886 /* ecmult_gen.h */,
+				CF3472CD4D6EC8A85F4709A83062E589 /* ecmult_gen_impl.h */,
+				FAAD058A045B19FB88C786D6B60224BE /* ecmult_impl.h */,
+				ADAB8FD05505F6681B106032F4D674DA /* field.h */,
+				B4AAF8307C81ED675D28AEDEAA3CA402 /* field_10x26.h */,
+				341304168E0921272AD3C19EC05F5B5F /* field_10x26_impl.h */,
+				2B0C4497D7B3C9C961FCE0CFEE1099B8 /* field_5x52.h */,
+				BD68A36110A4FCF3C1583F018F78F1FF /* field_5x52_asm_impl.h */,
+				A8D72BD9A6E8FD6F0F5846DCD6B06878 /* field_5x52_impl.h */,
+				3E856872418F8844D28E0CBEA13BA203 /* field_5x52_int128_impl.h */,
+				A0A296B44654179E862676929D0D08A4 /* field_impl.h */,
+				E713368D9AFBF25CF62922ABCCA8103F /* group.h */,
+				7AC84DAA646EBB604B4ED6B56F4D44F7 /* group_impl.h */,
+				88F992F8D3048AAA721EAF25366808A9 /* hash.h */,
+				7FDF73BA0AACCB5EA52DB51BCF9CE9C8 /* hash_impl.h */,
+				7494F2FF241624C4C0B13986744BA168 /* lax_der_parsing.c */,
+				25C41C40F3239FB7F59F4EBEB0A3511D /* lax_der_parsing.h */,
+				05EC65CDE06E17433DBA29F7002C5EDA /* lax_der_privatekey_parsing.c */,
+				1D1C71B00EC0B4FF2154BA22D57B1B84 /* lax_der_privatekey_parsing.h */,
+				B2DE48CC3A2DFD167480E64360EA9259 /* libsecp256k1-config.h */,
+				BD64EE5E17635F522BEC667AE08BAB92 /* main_impl.h */,
+				C1BFC8E2A0E61395AB165CA6C1500F71 /* main_impl.h */,
+				30FD6BFA988D38667768E1C7E6659270 /* num.h */,
+				E7D304295737E8DA2F6371A63E7DD0BD /* num_gmp.h */,
+				E3BD777C11653A6C3DAA29269D27CEAC /* num_gmp_impl.h */,
+				0C10B9EB6F4E1EDBF4259BA73B1B1345 /* num_impl.h */,
+				6BBF9DAE2BE96268A66EC11337DE66CE /* scalar.h */,
+				101EE83D4F406DE2BC20E6ABE6A438C7 /* scalar_4x64.h */,
+				901D5132242D3951B5833E7F5E0BBB00 /* scalar_4x64_impl.h */,
+				96803255870FC0B988C5D3FF3EC38DF5 /* scalar_8x32.h */,
+				0BE47D22AA958D9CD94C0B7B99F0CA68 /* scalar_8x32_impl.h */,
+				DEA833EC1FB428657D0AFCA543D5BD48 /* scalar_impl.h */,
+				5DA9457B5C2C61A5998AB2070FDE20B0 /* scalar_low.h */,
+				C1115E6596EF196DD2291F81C4C9C181 /* scalar_low_impl.h */,
+				3D296AC4874D9018CD682D9BA4930FE8 /* scratch.h */,
+				DD812908B6A8A5739F6E827AD436419B /* scratch_impl.h */,
+				9D48A17683BDECE084550AA6339F9CEC /* secp256k1.c */,
+				E147C791AC66BEF59781D15B1BBA68F6 /* secp256k1.h */,
+				04AE81D5DB9F4D8240587148767BDFF6 /* secp256k1_ecdh.h */,
+				9F29B0076CE93A7FC836359D228078A9 /* secp256k1_ios.h */,
+				2AC6A9765FDB4EADF4B8864803E1690A /* secp256k1_recovery.h */,
+				7DA768214F620DEBF8CB0659D04D1A5B /* util.h */,
+				FF0431ECE19ADFC65A11233E25AFB955 /* Support Files */,
 			);
-			name = Pods;
+			name = secp256k1_ios;
+			path = secp256k1_ios;
 			sourceTree = "<group>";
 		};
-		7D7949CA83804BC8CA5E2ABDD29856E1 /* SipHash */ = {
+		701D794A27D07DCD8FE87E8EC3BB4C44 /* CryptoSwift */ = {
 			isa = PBXGroup;
 			children = (
-				6F57ECA9E5BBCCC7BCCCEBC506FE75A8 /* Primitive Types.swift */,
-				6CF0A2349580453266D55F969B32F05B /* RandomUInt64.swift */,
-				922C288F68253A0F8165786CEEDC1634 /* SipHashable.swift */,
-				714A2D37F8F87E883F046D7828AB6D98 /* SipHasher.swift */,
-				F896B1D4154D64E21FA7735B9A52C59C /* Support Files */,
+				467F795F6A9C3E0DFDD0FE46DFDC5186 /* AEAD.swift */,
+				F2A3ADDF7A53DF282AE4E6A160C657D2 /* AEADChaCha20Poly1305.swift */,
+				DDE1AD5054A208E4D3DB80B6C9F6916F /* AES.swift */,
+				C8CF67230FE1CA91342AB81CEBB19158 /* AES+Foundation.swift */,
+				3219EF7CD0C2F08F7F966C59EBD7E201 /* AES.Cryptors.swift */,
+				94F095D6675E92DB361EBD6ED6641597 /* Array+Extension.swift */,
+				87C4E22693024283CEF1CE5EC99BFEF1 /* Array+Foundation.swift */,
+				20C7E60C088422063704BC0D090F67C9 /* Authenticator.swift */,
+				6AC95AC35C6E78B9879CAFF04EEB9578 /* BatchedCollection.swift */,
+				91FCC94DF64D415579856A46E9AE144F /* Bit.swift */,
+				2081C4B784593A557274AD122C985317 /* BlockCipher.swift */,
+				EDCF6AEDC0537776CE0D24F9F130750D /* BlockDecryptor.swift */,
+				9E1D1283598DD9FB40501814B446C432 /* BlockEncryptor.swift */,
+				CDB95A76496EDC5724E41797B5EE2F51 /* BlockMode.swift */,
+				BA589F8FC69C78A18A71046F844CCF3C /* BlockModeOptions.swift */,
+				4589A3D54AFD2251264C4910E695872B /* Blowfish.swift */,
+				D841A94F02EE18231C3A6082413C6926 /* Blowfish+Foundation.swift */,
+				400974DD0BAFA502C534CED0FDF36E4F /* CBC.swift */,
+				564EACCD48CFBD4ED24477096788B35F /* CFB.swift */,
+				466E434A39BBD238A4D05E63F2A34E4E /* ChaCha20.swift */,
+				40D9F663926E8B062E03E5DEE5432224 /* ChaCha20+Foundation.swift */,
+				0CE7DE1D82E20261BF472C2DA17A014A /* Checksum.swift */,
+				1B979C8BAE317028F54D235D2A0CF1BC /* Cipher.swift */,
+				313120D6B0844C95111E1650DE5B68E8 /* CipherModeWorker.swift */,
+				8A96BA88952EE60DACD64504880387B6 /* CMAC.swift */,
+				9BC61D2173A7D897CEE43E9ED30B3858 /* Collection+Extension.swift */,
+				5C54B58C29DFD97FBC7100505A8C2600 /* CompactMap.swift */,
+				5E53A5B5BC58ADF41631607A5FD30732 /* Cryptor.swift */,
+				E076F4231256E2BD592009B01EAB1489 /* Cryptors.swift */,
+				D72B89AF39754D5394CDDA89EF1FE910 /* CTR.swift */,
+				B15A11FE00702C88874F947C5C5D37DA /* Data+Extension.swift */,
+				A84FAB4B01608C152C252FB69EF57D28 /* Digest.swift */,
+				20376F2F2EEE94392F56BFCD0AAA921C /* DigestType.swift */,
+				D79791C3084EDB6DCB40FDB9CC457AC1 /* ECB.swift */,
+				7F5EF4474394372C33D5AD7DF8A0065C /* GCM.swift */,
+				E96BEA8AB7CDEBF6D2FFB21A021A7E8A /* Generics.swift */,
+				70BE5D5DB99C60B6ECB4AA4CDCECFCC4 /* HKDF.swift */,
+				4B5D61860F5FD79DD8123BCB7ECA75EB /* HMAC.swift */,
+				39DA4F4135D16F7846D98A5D136594EB /* HMAC+Foundation.swift */,
+				5229EE3657A2EDF787D3C3D30FF03335 /* Int+Extension.swift */,
+				B6473E6D83C12C75419CCA654011714F /* MD5.swift */,
+				08B60815E6AF7C1CE2B12FD7EF5E935D /* NoPadding.swift */,
+				1D7BEA031DC24D8856BCB2D0F517DC6E /* OFB.swift */,
+				7475B3B61C275359424F637C0994879B /* Operators.swift */,
+				917317E7E493C550E2E327E0D1616711 /* Padding.swift */,
+				70BCFDA3C56415A6D1EB95194CF8B592 /* PBKDF1.swift */,
+				ABD7F26A557D98A7C91689CB5A60D36D /* PBKDF2.swift */,
+				6416379E455C5139431635058364658B /* PCBC.swift */,
+				EDFA1AE34EF824D45F5201833B299CFD /* PKCS5.swift */,
+				30AF75932BDD1310CF0BE737574BB8EB /* PKCS7.swift */,
+				D5231B7A7C9D35B5D55A46943A58E7FD /* PKCS7Padding.swift */,
+				CDFEF8A63F93FB41D6119F765F6D3B0C /* Poly1305.swift */,
+				0A31C3BD52129B6DFCF9A0C8BCEE1781 /* Rabbit.swift */,
+				FDF1750F92AA20B76F5A46748B45B385 /* Rabbit+Foundation.swift */,
+				8593E76FB1B8AB27CB5F8CAFC9E5CE6A /* RandomBytesSequence.swift */,
+				D8E47EB0AFC3A421CC5AB0E56AABFBA8 /* SecureBytes.swift */,
+				F69FE100A8E9CB0B6B86E4A44DFF1824 /* SHA1.swift */,
+				471B3967D8491DAB0642DC353C096A6D /* SHA2.swift */,
+				C6A17E180C775F133971F5BEA1EC703F /* SHA3.swift */,
+				BD339B1454B79A6400983A439AF3AE02 /* StreamEncryptor.swift */,
+				7782FBF474D27894445865F06B1F5AC2 /* String+Extension.swift */,
+				A79DB94B5E2289A1FDE5D100D10433F4 /* String+FoundationExtension.swift */,
+				6C27A154651D4F380BA194E9F6FE8C89 /* UInt128.swift */,
+				B5D1E41FC7CE889C03F43819CAC906CC /* UInt16+Extension.swift */,
+				614F03A94B3CA7BCFE7AD4B98555030F /* UInt32+Extension.swift */,
+				12D685FF90DAA694471CB5BE3721EB71 /* UInt64+Extension.swift */,
+				E2DE5E21F680A68C6578671B653D71B8 /* UInt8+Extension.swift */,
+				051DA8488AF7DF4EB56C80335B4E0AAB /* Updatable.swift */,
+				A3871425630F3D873F76F3BC235328D5 /* Utils.swift */,
+				202049474E0CCA0236B0BB25EB3F7428 /* Utils+Foundation.swift */,
+				244B6FF4B1380D326D4C5E6F093CEB7A /* ZeroPadding.swift */,
+				C062B03847835EC8EF560BE403125BAB /* Support Files */,
 			);
-			name = SipHash;
-			path = SipHash;
+			name = CryptoSwift;
+			path = CryptoSwift;
+			sourceTree = "<group>";
+		};
+		73F1DF5F11D29BC1A267853CD2F05F10 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				2E642192739CEA390C92AC0356DF0B56 /* Alamofire.modulemap */,
+				056672AFA34A366E30A383A25346F6F6 /* Alamofire.xcconfig */,
+				AF08B8DF071710D784EFFB10758809CD /* Alamofire-dummy.m */,
+				86A69359324812DC9B4294B6EC6A9D11 /* Alamofire-prefix.pch */,
+				01CF0F29ECE5A077234420623654BBBB /* Alamofire-umbrella.h */,
+				863D9CD5899EB41A44D01D4787039F50 /* Info.plist */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Alamofire";
 			sourceTree = "<group>";
 		};
 		7DB346D0F39D3F0E887471402A8071AB = {
@@ -1143,124 +1413,40 @@
 			children = (
 				93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */,
 				AE861416A612EE0C47395FAEF4FE7F95 /* Frameworks */,
-				61AF252354DA383FB4D5BFF297649F01 /* Pods */,
-				D7E726F612E66E49EC0F3C700D854B64 /* Products */,
+				CC635F913C88E151BF56D0A60385F400 /* Pods */,
+				84F42B9B27C7FD7D73B4BAC5290BEE4B /* Products */,
 				6141D00C50F788189760EAB700C0BF7B /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
 		};
-		8E713FDAB949489E2BCE0F6B1AD10022 /* web3swift */ = {
+		84F42B9B27C7FD7D73B4BAC5290BEE4B /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				8FD7D8C6393417BDBE5CF9362727B144 /* ABIv2.swift */,
-				70BA52C5917E5A43E50F5CFFA8520DCA /* ABIv2Decoding.swift */,
-				22281779014B1860B15BD0DFAFE85BFC /* ABIv2Elements.swift */,
-				5F1C9082978CBBE222D623A50BA9029B /* ABIv2Encoding.swift */,
-				A5BDC2A70C176E4B5CE53439F29006B0 /* ABIv2ParameterTypes.swift */,
-				BAD9140A70E4F1E11E22F06BF0413344 /* ABIv2Parsing.swift */,
-				147B6AEB73C3C9E8513DF4D79021E2D1 /* ABIv2TypeParser.swift */,
-				2FE2F408B4FF2738A9F42B10ABC90748 /* AbstractKeystore.swift */,
-				0D870040E819D9A05E8263137AED51C2 /* Array+Extension.swift */,
-				7C890F5D6BDE1F66CCC42BCA89FC70C9 /* Base58.swift */,
-				30556C7671D0B1E8F19FB68CFBF69F91 /* BigUInt+ObjC.swift */,
-				4A2D8F7A44C9A04DE2232E3D77A120B8 /* BIP32HDNode.swift */,
-				6E92704F9468A8DC78B75C3F8C46F61F /* BIP32Keystore.swift */,
-				23E716973755B2E89ADF5EFA78F9A5FB /* BIP32KeystoreJSONStructure.swift */,
-				BA660D6BB71673919923BCD02318CA81 /* BIP39.swift */,
-				58152D6BC0953D378603360B64894468 /* BIP39+WordLists.swift */,
-				0221BBBC730C21F3F41B6255DDE12A4B /* BlockExplorer.swift */,
-				52974B5C907F23B4873E61DEBD141134 /* BlockExplorer+GetTransactionHistory.swift */,
-				5EAAFE7F970149EEB716AF8A63B196BE /* BloomFilter.swift */,
-				88250D10A20EEB815A6E14FD5192E74D /* ComparisonExtensions.swift */,
-				166DE5D1E7F051FDD9702B9C7A6474AD /* ContractABIv2.swift */,
-				F6CB1D681610799419772BC3B32139EC /* ContractProtocol.swift */,
-				4DA7456076875720004B445B49676E91 /* CryptoExtensions.swift */,
-				2FEB134F3E9ADEE9834D6CA22599A7C6 /* Data+Extension.swift */,
-				0A5D4088DE323E1E6B0D8585711F435E /* Dictionary+Extension.swift */,
-				B7183803460616976586A715AFC5D10E /* EIP67Code.swift */,
-				1DD3729C3876B97234310E3E81099B8F /* EIP681.swift */,
-				5F0F9A14D8E737876058FD244DCF8451 /* ENS.swift */,
-				C75A2DBD7913BD159F4A5A5069428A96 /* EthereumAddress.swift */,
-				F45F460F0DE60D0DEC59CFA40E7BB519 /* EthereumAddress+ObjC.swift */,
-				760710F8F0DCFBEE321D645FC9EC8799 /* EthereumFilterEncodingExtensions.swift */,
-				92C45C929132142FE6689C2C4ED07BC5 /* EthereumKeystoreV3.swift */,
-				886A1282A062E66825671DF657D44E64 /* EthereumTransaction.swift */,
-				EF3C5B8DD6E4101232857EDCFB29BA3B /* EventFiltering.swift */,
-				C948126C72F61B79C50B629A1C0D183E /* IBAN.swift */,
-				EAAB7DFE95F896DE6A26D8D73762B632 /* KeystoreManager.swift */,
-				BADE7592EE42D062BA4138EA1897A189 /* KeystoreManager+ObjC.swift */,
-				07E8AB5ED7BFCC8954C8B2DD7245033D /* KeystoreV3JSONStructure.swift */,
-				6AAB871FAB1037C110E267D4796ECF8B /* LibSecp256k1Extension.swift */,
-				9E7CCA70CB80C09C9A5A309B5A9C697E /* NameHash.swift */,
-				EA8CCF59177FA9414B4E01275FA4B5B5 /* NativeTypesEncoding+Extensions.swift */,
-				7ACA44517F51EA28DB0C302D2051C522 /* NSRegularExpressionExtension.swift */,
-				3B393D0AD2B154707B21DD9E0151F093 /* PlainKeystore.swift */,
-				E2F42182F81F1407C3DC7D5771E3459A /* PlainKeystore+ObjC.swift */,
-				0FB37EF90329DC22848705FF392DE561 /* Promise+Batching.swift */,
-				3A0822E6C8EC34132E8689B41A4A9A42 /* Promise+HttpProvider.swift */,
-				C058AEDF0EDDEDF0E6CD7FFD7ACD7DBC /* Promise+Web3+Contract+GetIndexedEvents.swift */,
-				08ECEE2138B5CD007ED894A9B2302992 /* Promise+Web3+Eth+Call.swift */,
-				E4ACD9A5E6A4EF9A218662A89A9E5D6A /* Promise+Web3+Eth+EstimateGas.swift */,
-				D2F4E98031D70399B7BAA04C8BA36D16 /* Promise+Web3+Eth+GetAccounts.swift */,
-				AF007536B0CAD11C81F81E5AEAEF96C5 /* Promise+Web3+Eth+GetBalance.swift */,
-				CC93974BF783269BAC12B91F8592233D /* Promise+Web3+Eth+GetBlockByHash.swift */,
-				E35D3B343A717FCDB8D4F958E8312BED /* Promise+Web3+Eth+GetBlockByNumber.swift */,
-				308BEE6F5CCFBDD8FD9BEBF131AB4E0F /* Promise+Web3+Eth+GetBlockNumber.swift */,
-				D5B92DF881BDEE17A066C7CEB0832AF4 /* Promise+Web3+Eth+GetGasPrice.swift */,
-				AA5D7F458AEE45A98CE2A88398BCB385 /* Promise+Web3+Eth+GetTransactionCount.swift */,
-				1A02D0753403DB9CE76099B0776D3DC2 /* Promise+Web3+Eth+GetTransactionDetails.swift */,
-				1259AE93B24BF01BEE804884A4F978C5 /* Promise+Web3+Eth+GetTransactionReceipt.swift */,
-				28BD528A7DD471FEC544268CD2A7178C /* Promise+Web3+Eth+SendRawTransaction.swift */,
-				C646FB1DA299FF412F9BDC68F40E0E75 /* Promise+Web3+Eth+SendTransaction.swift */,
-				5B603A3DF5A832302D45AA5314EE8179 /* Promise+Web3+Intermediate+Send.swift */,
-				8FE69ED3CCD20098717723EC70FBA476 /* Promise+Web3+Personal+Sign.swift */,
-				65D5BB8EAB2F4FB5B4DCEAF94C6EB713 /* Promise+Web3+Personal+UnlockAccount.swift */,
-				DE93D1B7D324256F9D4C18FECD6123C5 /* RIPEMD160+StackOveflow.swift */,
-				F61B9122E3779351D03DFD6CAF5B0D6E /* RLP.swift */,
-				A41C3E6A280C712951F4529D21BF46A9 /* String+Extension.swift */,
-				03433D7E52F91A51BFA94E64D405A26F /* TransactionSigner.swift */,
-				7D46CDF03C9910792DA563A596A1AA6C /* Web3.swift */,
-				4499FB78EF2CA976271E1DD561F132B5 /* Web3+BrowserFunctions.swift */,
-				2F96370375D8B9AD1B4754DC3CE3C556 /* Web3+Contract.swift */,
-				3AF492F3A7A03C60C5BF133362B1AF65 /* Web3+ERC20.swift */,
-				DA2BE125C18E4B43224734B6002B0467 /* Web3+Eth.swift */,
-				47D1682813F759C273A31C2B4B5C5A95 /* Web3+Eth+ObjC.swift */,
-				6522C7D53C4ED1BCB2C616D342D0C211 /* Web3+EventParser.swift */,
-				CB48D68DCB17B1C07B05A6D6B3EDC766 /* Web3+HttpProvider.swift */,
-				CAB3CE396AC863066AAF026DEB3D6551 /* Web3+HttpProvider+ObjC.swift */,
-				62BAFC302544761C154C3C312785A956 /* Web3+Infura.swift */,
-				A760383154BE7CDD10490704A13AF43E /* Web3+Instance.swift */,
-				1609F2A0E3EB4DB99EABA47647E2DA28 /* Web3+Instance+ObjC.swift */,
-				0564D106B866DFD63A27D0AE1AC7AA21 /* Web3+JSONRPC.swift */,
-				6A80FA1CCA53746C9DA607B2D8DEBD36 /* Web3+Methods.swift */,
-				7A737611902B285FF9F052CF2E61EFF8 /* Web3+ObjC.swift */,
-				1E5132DAC664B220CCE54C66915EA32C /* Web3+Options.swift */,
-				E539160B76CACFD6BA902BA856B30B06 /* Web3+Personal.swift */,
-				61D095D938B024427A74E17FEFDC681E /* Web3+Protocols.swift */,
-				A3BECC646855C9D5F421B3EA83BF6EC9 /* Web3+Structures.swift */,
-				F823FDD38A4551CF9D48F30E8B333E78 /* Web3+TransactionIntermediate.swift */,
-				A00EF881409ABAAA333E7D4C52F6FA0B /* Web3+Utils.swift */,
-				0A29D991D251FA407E8574127CB40CE3 /* Web3+Wallet.swift */,
-				BF8B7DC811049895554DA6E7651A5692 /* web3swift.h */,
-				CA32154A733AA095D64909273E33AF19 /* web3swift-Bridging-Header.h */,
-				9146877C57D1B5BD58E05DA473BB2E40 /* Support Files */,
+				0F000ADE280FAB3A7DF2252A18CCF5ED /* Alamofire.framework */,
+				124CFE84E65BE490249D7B32E18CD4CB /* BigInt.framework */,
+				4036E3F8719C9DA138447CF896990DF0 /* CryptoSwift.framework */,
+				5AF3EA57EE4D3FFB37E2559DBF18CC6C /* Pods_DiveLane.framework */,
+				A23101FBFEBC11DD104C764E8151CD01 /* PromiseKit.framework */,
+				87005B64D352C9CF9D7A7B052F8733B5 /* QRCodeReader.framework */,
+				1A5215C0DD24304684C972DFFF7D02FC /* Result.framework */,
+				20097552F3A1817336DAA2939737D312 /* scrypt.framework */,
+				03267157904456FAC7624F692E910B55 /* secp256k1_ios.framework */,
+				CEA2FA56B1D5976585D96D52DE483E3D /* SipHash.framework */,
+				2737110627995C56D4523BEED35D20E7 /* web3swift.framework */,
 			);
-			name = web3swift;
-			path = web3swift;
+			name = Products;
 			sourceTree = "<group>";
 		};
-		9146877C57D1B5BD58E05DA473BB2E40 /* Support Files */ = {
+		897A3321253E4EE495EB38CC7E79307D /* PromiseKit */ = {
 			isa = PBXGroup;
 			children = (
-				E0F5F8C80C4653B3EBF1B9795FD9B567 /* Info.plist */,
-				767567F023FAC512B3AA4051D088CE0B /* web3swift.modulemap */,
-				0A82428D09BC54E0EE0DA1B4F9A0D20A /* web3swift.xcconfig */,
-				74C4F7726797CD7DABAEB28367A6E6CD /* web3swift-dummy.m */,
-				86FC360AE9099D7D5A4F0FD29FE481E1 /* web3swift-prefix.pch */,
-				90C8F8375B636A25054B8B6C8A00DAE0 /* web3swift-umbrella.h */,
+				0DD294729847EF2B8AD5731CFB0E53F9 /* CorePromise */,
+				B8FB02668584D0AEF25EE3433C443671 /* Foundation */,
+				B2080A2A29EC05DB12B702D9CB80E470 /* Support Files */,
+				A147463422E1D76135986D324BD620AB /* UIKit */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/web3swift";
+			name = PromiseKit;
+			path = PromiseKit;
 			sourceTree = "<group>";
 		};
 		9273CD5A92ECCDFF8CAE95C86DC604E0 /* Pods-DiveLane */ = {
@@ -1281,123 +1467,63 @@
 			path = "Target Support Files/Pods-DiveLane";
 			sourceTree = "<group>";
 		};
-		9989E08DEF40977CB40DD3B99F95B14C /* Support Files */ = {
+		9C15914AA3E89EEAC3D02D27D10F6F18 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				984F3E1BD001B0D5BEC00D1601FE7420 /* Info.plist */,
-				695E0D04AB9B729454BADA86F2F4997E /* QRCodeReader.swift.modulemap */,
-				B3CFB7A375AE11906A99E54EE63DE37D /* QRCodeReader.swift.xcconfig */,
-				CE8979EDA54F76059818F7D9272FDDCB /* QRCodeReader.swift-dummy.m */,
-				8FA31A44D782F31BF67CBA776CC6E024 /* QRCodeReader.swift-prefix.pch */,
-				1F544D2A20CB42C44EBFB2EE25824C5D /* QRCodeReader.swift-umbrella.h */,
+				27AEAB3F76DC9C5C04CF7CF72FD5C3FC /* Info.plist */,
+				431DAA8C35760A30EAD4D2C1E41D8C1C /* Result.modulemap */,
+				228079A457478E0D94A95DD898CE5D74 /* Result.xcconfig */,
+				248F8DA7C2CEF6BE3B419CC9FF46EE91 /* Result-dummy.m */,
+				1A0C29952F599D246626EF905818042D /* Result-prefix.pch */,
+				AAECC5EB37FA21B358456B45631F17FF /* Result-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/QRCodeReader.swift";
+			path = "../Target Support Files/Result";
 			sourceTree = "<group>";
 		};
-		A53E5122EB85BBFBD2C9F2807980DDF9 /* Support Files */ = {
+		A01376561EAE237CF8F9BF23C6C5F58A /* scrypt */ = {
 			isa = PBXGroup;
 			children = (
-				3D75797CE630F3A25D64B559810F3930 /* CryptoSwift.modulemap */,
-				08FEE5DD01F91DFDFB96333BB631B52F /* CryptoSwift.xcconfig */,
-				0FD4D52CF24250A1E2C8CDC4EAC746E4 /* CryptoSwift-dummy.m */,
-				58ABCCBE5A99415F6F404C6824E5CCE6 /* CryptoSwift-prefix.pch */,
-				A91184E78522CDA56B22FF1EDB1C3AC1 /* CryptoSwift-umbrella.h */,
-				9A8E5CCAA68BC39EC9E90A422E2FD22B /* Info.plist */,
+				EAB070DE5C274B1063284536E06DF63A /* BufferStorage.swift */,
+				2F6B987B7208100A40ED658C534AF947 /* Cimpl.c */,
+				A728C96D2D6447B46FB27C5908606294 /* Cimpl.h */,
+				C9AF4BA027E7452FA710EAC1913382A1 /* Salsa.swift */,
+				EA2334F5B6CC246D4C90FF86CF55D594 /* scrypt.h */,
+				2CA7EC0C1DB8C4EC5D96730BBACB27B1 /* Scrypt.swift */,
+				4C3BA0DB2DE862FB9F6AF3BD8F298095 /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/CryptoSwift";
+			name = scrypt;
+			path = scrypt;
 			sourceTree = "<group>";
 		};
-		AB5B650DE62CB5FBB2B7901F107B4CC7 /* CryptoSwift */ = {
+		A147463422E1D76135986D324BD620AB /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
-				423DE1FB7639986D2A99739DD9F77803 /* AEAD.swift */,
-				732314F22D2BE49B430C8F340F5E8B86 /* AEADChaCha20Poly1305.swift */,
-				EC6FCDEC38554B2B6C697FE4E71B357F /* AES.swift */,
-				B45CEDB397684979E7A94F5717A7DFB8 /* AES+Foundation.swift */,
-				1816075B02B575B1BE7B00CDBF253774 /* AES.Cryptors.swift */,
-				667F734F7FA99E745C2835EC2DA2C4BF /* Array+Extension.swift */,
-				D97A5FA3F03B5FC2E2E8D181D2D00D06 /* Array+Foundation.swift */,
-				1704372B6C03EF041EA1BFCBABD488C4 /* Authenticator.swift */,
-				7F4EDAD930B01C250C0F748F8CA2C7CC /* BatchedCollection.swift */,
-				8086578C0DC7EF0622EC041A26E4814C /* Bit.swift */,
-				4E5D58CDD8D4E7674C84DF5A317C398D /* BlockCipher.swift */,
-				86AF320F445F837D3DF7F3CA83C7E676 /* BlockDecryptor.swift */,
-				493CB8292859030078340B11BFF6B29F /* BlockEncryptor.swift */,
-				FFEA9371FBA0B1B3B64B73679B9ED051 /* BlockMode.swift */,
-				34002D3C3F98CE707F793AD0F71482BD /* BlockModeOptions.swift */,
-				4CAA5E70273C0F733622CF994C04E8D9 /* Blowfish.swift */,
-				608A1FDD759AE0938FDE3DC293A06A34 /* Blowfish+Foundation.swift */,
-				F59FCF5E84197D2A24E0AAEA2AC41BAB /* CBC.swift */,
-				6324C43D4F9B2EC0C44B602C73FA7999 /* CFB.swift */,
-				54D1A77434D0B4FEE3D3DE61CF971BAA /* ChaCha20.swift */,
-				F731FE642E29D942A2602E615A503A8D /* ChaCha20+Foundation.swift */,
-				050032CBDB96B47020EE0C79B908B9D4 /* Checksum.swift */,
-				AA9E33D7B35D7414F58825BD46C796BB /* Cipher.swift */,
-				BB0756499BD68CE88386F1DDE23712AD /* CipherModeWorker.swift */,
-				380037FD51C7F639654C9836CAE2E5F3 /* CMAC.swift */,
-				D3DBEC6C530117F3405599A1A23356FF /* Collection+Extension.swift */,
-				31B00CFBE0F680096E1581F6B59A0F5F /* CompactMap.swift */,
-				FBBA16F895F2F9128478336664AD83DB /* Cryptor.swift */,
-				FCA59745B42B4791921F39555C5670F4 /* Cryptors.swift */,
-				9334E5543C9956623D4BFAA9E0560258 /* CTR.swift */,
-				3301B9C2C1C3E440033DF99B705DA5FD /* Data+Extension.swift */,
-				D4BD253F42CDC5D32643550402722E85 /* Digest.swift */,
-				1FE6F70BF47E8B23A975E5B8605326AB /* DigestType.swift */,
-				B8AE5D5F696161490EDCAAB4F1337C16 /* ECB.swift */,
-				6F7E1C14BBBF779E4B6B5F784AFCFAD7 /* GCM.swift */,
-				09A11BABC7FF560066D62BD1E5688FC7 /* Generics.swift */,
-				B8CD9A900727202456B18505B6F9D3AA /* HKDF.swift */,
-				39F845E5734F0004AFE3813BA2D1956C /* HMAC.swift */,
-				E1EC6F414C91B379A64B34DAFBB3B3C9 /* HMAC+Foundation.swift */,
-				D0CDDBC20612961CC37CD4D522A380D3 /* Int+Extension.swift */,
-				946A2B9F0FFB6DC6145CD5838ED9DF46 /* MD5.swift */,
-				45C2948CBB2860088420738DCCAFEA2F /* NoPadding.swift */,
-				F570D9AA2AB57C2A5EBF29E6082D9732 /* OFB.swift */,
-				96AC6410BC3F9BBCCD4AE87C8A69D8A6 /* Operators.swift */,
-				B42AE7B67420B67F1EACEBB856F114C6 /* Padding.swift */,
-				A1785C3404F91CD2610553CAD01F14B0 /* PBKDF1.swift */,
-				112A6FCDB04E7C609AE8977DC87F23E4 /* PBKDF2.swift */,
-				A0C1173CE60CDE5D71AF73564BBEF041 /* PCBC.swift */,
-				8B887CA868DF2DE1DB203D6F4FE718AC /* PKCS5.swift */,
-				5DD25864EC42F1D4A3ABE45779307FB0 /* PKCS7.swift */,
-				C6C238D4F471736091D3722367119066 /* PKCS7Padding.swift */,
-				2D13A6F0B7FD06E7185579216C8C9F45 /* Poly1305.swift */,
-				68B4BB25775036EC78B3BF4A5BE8FE39 /* Rabbit.swift */,
-				AEE7DAE7FE8050EFB9EAEA05710A4984 /* Rabbit+Foundation.swift */,
-				17D01587ACD40F5E9332D90792B4B2A6 /* RandomBytesSequence.swift */,
-				1CA0C1C52EAA18703E1E942509B0F8E9 /* SecureBytes.swift */,
-				7E15938B0E01C7540EED1359881D8F0D /* SHA1.swift */,
-				495C0ADF7FE8768DC36EE0D4CCF706BB /* SHA2.swift */,
-				D2A9342EAD85D9110FF0B04FCF37DA4F /* SHA3.swift */,
-				7EBB7522F3404A3011852D8BD477968A /* StreamEncryptor.swift */,
-				4B6DE265854D1861093D783AC9356B49 /* String+Extension.swift */,
-				E225FF94575A6EAD117CBAF7BDCE9804 /* String+FoundationExtension.swift */,
-				5552C4D8C9464EDF1E94F0B4FA62ECA5 /* UInt128.swift */,
-				9C0CCD3ADD8A757A11862385A5B31AF4 /* UInt16+Extension.swift */,
-				EC8289F3C94B21C93376E2FB4DE31BFF /* UInt32+Extension.swift */,
-				B114219677B4C10C3E66F96A5BC6DD81 /* UInt64+Extension.swift */,
-				638651C3710123A24F0E3D5389F38244 /* UInt8+Extension.swift */,
-				EBE72EDE01F89A09C540AE649E97C3C9 /* Updatable.swift */,
-				E99222AE65965EACC01E443FD9F22658 /* Utils.swift */,
-				168447759BCDE275D179C1B1B07182E5 /* Utils+Foundation.swift */,
-				C939D64636F1F2FFF721FDE6005F2F0D /* ZeroPadding.swift */,
-				A53E5122EB85BBFBD2C9F2807980DDF9 /* Support Files */,
+				502435EEEA3CAA6A5A83F0BB7EE5EBA9 /* PMKUIKit.h */,
+				930ABC6D2AB929B6B0B0EF49AB3FF50B /* UIView+AnyPromise.h */,
+				96D1D17378722BAD8574D405DC1F248B /* UIView+AnyPromise.m */,
+				EDA911506B7BC5F109F11E624B3B58A9 /* UIView+Promise.swift */,
+				63CA4DD74FB0F34DA9088C2DD00A6C7D /* UIViewController+AnyPromise.h */,
+				10A0AD3FD6958085628104AAFCB8C3C1 /* UIViewController+AnyPromise.m */,
+				C2F2B3C6389C3B20BA6089734B930EBE /* UIViewPropertyAnimator+Promise.swift */,
 			);
-			name = CryptoSwift;
-			path = CryptoSwift;
+			name = UIKit;
 			sourceTree = "<group>";
 		};
-		AD8EB3600FFEBC42F621C6215A9EA5BF /* Fabric */ = {
+		A1C9EE2B9728C5B2B32088DBC0311C54 /* Crashlytics */ = {
 			isa = PBXGroup;
 			children = (
-				35053C5AA7E1933A4C94C0C1AAFBEE9D /* FABAttributes.h */,
-				1E4062B2458ED0DE8907C21F000DB3C8 /* Fabric.h */,
-				525538D21843EE8522B7C2F626C4BB91 /* Frameworks */,
+				934C1504034E7C96CF606D636CA3FFF9 /* ANSCompatibility.h */,
+				7F25A24DD78BCF6EDFB6B16B1BD7BA43 /* Answers.h */,
+				A2573C14613EBF2FC6834A49B8139389 /* CLSAttributes.h */,
+				9F7EFD8D6B5A34686C4E7CC299B952B8 /* CLSLogging.h */,
+				E899A2A35BBA0421324C952507C42392 /* CLSReport.h */,
+				2FF2E0A2D5E5A09BACB089A01FBF1FB7 /* CLSStackFrame.h */,
+				5206A86DDC8B1123CCC4220921B4ED0F /* Crashlytics.h */,
+				C37E37BBBA7F60FA55B948C3958D61E7 /* Frameworks */,
 			);
-			name = Fabric;
-			path = Fabric;
+			name = Crashlytics;
+			path = Crashlytics;
 			sourceTree = "<group>";
 		};
 		AE861416A612EE0C47395FAEF4FE7F95 /* Frameworks */ = {
@@ -1415,157 +1541,196 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		B3692DCB079DD8F8598E877B33F3AFDA /* Support Files */ = {
+		B2080A2A29EC05DB12B702D9CB80E470 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				1C5E2C13B77294C17BEBCF185D2C71E7 /* Info.plist */,
-				CA571F033887A13B9CCA85633781014B /* Result.modulemap */,
-				C3DC8E36D9095B4B0AA882FF480B7161 /* Result.xcconfig */,
-				B2D0C7941B416A9892CDDBD96789C132 /* Result-dummy.m */,
-				C7C061174C15AD0DCF8A94EA425FBAF5 /* Result-prefix.pch */,
-				721ED87D8D0B64B0CFE26E691A3626E1 /* Result-umbrella.h */,
+				BEA91E988B77C6D1AF10C93F0DE1A23B /* Info.plist */,
+				5E8BD85FC52AE77C7EDC80C09626560E /* PromiseKit.modulemap */,
+				A072AF0ACC773EF3B8B92B46FEC26400 /* PromiseKit.xcconfig */,
+				823DAA23988145C04C357EBFCE95FAA4 /* PromiseKit-dummy.m */,
+				5956074886CED0A604FBDCD722BA8887 /* PromiseKit-prefix.pch */,
+				BBB2E83B0870410A5D08B5DF62BC0BB0 /* PromiseKit-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/Result";
+			path = "../Target Support Files/PromiseKit";
 			sourceTree = "<group>";
 		};
-		C49685B3B3104A8AF4B1FCDEC161092B /* scrypt */ = {
+		B3916E20DC5615889E9CC302CF0CC83F /* BigInt */ = {
 			isa = PBXGroup;
 			children = (
-				C50A145B512B01C48B19A84D643FB5DC /* BufferStorage.swift */,
-				CF68056D625032F4519B4087C11B8241 /* Cimpl.c */,
-				6F63C1B9F2BDF4747B7CBE35E7A0563A /* Cimpl.h */,
-				423D77A5F4F4FFA5C61FD1B9BC580B44 /* Salsa.swift */,
-				B6761F1748940B1DDC2C2B4EC1A2A625 /* scrypt.h */,
-				0DB998FAD907A6E5DFD87374AF7CA9D4 /* Scrypt.swift */,
-				F6D3B32CAE7B2CC744FB92BFE806D159 /* Support Files */,
+				3D89FB56598E9FDF2253200788961542 /* Addition.swift */,
+				693BFC0D19556FFCE33111EA56CCAC03 /* BigInt.swift */,
+				55D9A86A09328B52065F37F62B0DA725 /* BigUInt.swift */,
+				F4760D4934E5BC86AFC5A4E4A63E99D4 /* Bitwise Ops.swift */,
+				38A7C4F04F7073B982C3391CAD512EE2 /* Codable.swift */,
+				8C3F9B931E5DF95AFAF706D8FA6CC55C /* Comparable.swift */,
+				14FD914ED903081DB2FE4C26E38D3865 /* Data Conversion.swift */,
+				FA9A2A62C6BE578858DAF7399D3F4241 /* Division.swift */,
+				ED8175B9D465CE6E38ABB43A417B0416 /* Exponentiation.swift */,
+				BD24CAA8870B6EBFE6E6833B8DD551BD /* Floating Point Conversion.swift */,
+				A380ABE0FF9C088B8F0379EECF25B523 /* GCD.swift */,
+				F4ABFDA4F6189C60A794986F555A9C0F /* Hashable.swift */,
+				96258CEA10BDDD00990C9B904A3AA9D2 /* Integer Conversion.swift */,
+				264A299CE22746F7C0CF181C6950609E /* Multiplication.swift */,
+				E49B215782D27272CEBB1CCE548EB490 /* Prime Test.swift */,
+				5098F30FAB47D07396CBB0BE1DFED618 /* Random.swift */,
+				B2467C8F75C056D0510A2DC383174166 /* Shifts.swift */,
+				E089341E2F3DB80083CC5A32964F8E67 /* Square Root.swift */,
+				9CBB1FE361AE2CCD511B0C4C5EB4F94C /* Strideable.swift */,
+				C0D2CE11C62E522B7B555D073C66C724 /* String Conversion.swift */,
+				CE5299483F73A2F9F3D986E18B127574 /* Subtraction.swift */,
+				42F13C96ED45C95FC41551CDE5A6D68F /* Words and Bits.swift */,
+				CF0FC5307DBDC36DA8459B0F10F1C65E /* Support Files */,
 			);
-			name = scrypt;
-			path = scrypt;
+			name = BigInt;
+			path = BigInt;
 			sourceTree = "<group>";
 		};
-		CE4A66EDA1C5ADA494575225F588CC14 /* Result */ = {
+		B8FB02668584D0AEF25EE3433C443671 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
-				EAADA0F39A44626A22386624E9CA132A /* AnyError.swift */,
-				CDE57327670FC8906B9D407E2D978DD5 /* NoError.swift */,
-				6111B1E010967857A74EF10904989919 /* Result.swift */,
-				EE657AF6DA9389F135A039CFFC4A748F /* ResultProtocol.swift */,
-				B3692DCB079DD8F8598E877B33F3AFDA /* Support Files */,
-			);
-			name = Result;
-			path = Result;
-			sourceTree = "<group>";
-		};
-		D7E726F612E66E49EC0F3C700D854B64 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6138927DBD256234EEF7A0607055F4A5 /* BigInt.framework */,
-				16F2514116997A54740C8C2A17DFF32A /* CryptoSwift.framework */,
-				EBC92B4AF7864EC6077ECBDD382F325C /* Pods_DiveLane.framework */,
-				3AEED4ACE3931CCC34F30F806D423E05 /* PromiseKit.framework */,
-				17F02B1964D22AE7E6879024A6E2A0F8 /* QRCodeReader.framework */,
-				EC1CF885E556C543E884514C774065EA /* Result.framework */,
-				29B7168224886EC79F36144E6EF63DAA /* scrypt.framework */,
-				637AA645BCF8A061118CCDB1207C8A69 /* secp256k1_ios.framework */,
-				E77FD6D23CC86CB4BDE310436BABA615 /* SipHash.framework */,
-				3DA6E7C8123A0A5F0EF271F7C109EB9F /* web3swift.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		E27D4BB8774F1FD558E87CA98BF52B24 /* CorePromise */ = {
-			isa = PBXGroup;
-			children = (
-				5A8DDB6D2B5E479727139DEE5E29C989 /* after.m */,
-				A2D8F9E8F18C8FE7181B08A0B71CA1A1 /* after.swift */,
-				42BE142C960BFDE5BCC533A324E49F38 /* AnyPromise.h */,
-				66912792AB23217C495C7D419F13EE63 /* AnyPromise.m */,
-				76D19F9EAEF25529BF3F3B331F292817 /* AnyPromise.swift */,
-				5D2F80B6633B1B0FC06182C5EEBFF4CC /* Box.swift */,
-				35CAC501877E70427E127EFA88E10199 /* Catchable.swift */,
-				714DAAE8E7D5ACDCCA832E4C597E499D /* Configuration.swift */,
-				C13689EA7380E49B83A5D99C87E16871 /* CustomStringConvertible.swift */,
-				F4FBA9F9CF2F485F33DCE5586671C9E7 /* Deprecations.swift */,
-				53DBFB7B72D0AEA4C3DFC83B0D922333 /* dispatch_promise.m */,
-				71B75973741B8C0A92BDD1A39BF6176B /* Error.swift */,
-				2F0620E42997A0C97E03AAE8CC8BCFBD /* firstly.swift */,
-				67D0F512593FCE3F829AA0A99A087829 /* fwd.h */,
-				07F4E9080671022998131E7FE850380D /* Guarantee.swift */,
-				53C2D41F3888015B5D33A898FD0BDBA2 /* hang.m */,
-				2FAD6B3A1AAE9F168F997480BD36871A /* hang.swift */,
-				3203CE8CEACEE908C8FCE44171BF2FE3 /* join.m */,
-				968A1F9CB0E9C9ABD4D80279F7EA55AD /* Promise.swift */,
-				52242637417D88569D291E75739F18F0 /* PromiseKit.h */,
-				34F48B3606186F56C547BBAC70FE9E42 /* race.m */,
-				E25B56E6AB08ACA0EE1CC7ABCA0292C7 /* race.swift */,
-				F2F218A5404769FBD65244D21C4C1632 /* Resolver.swift */,
-				21557C62840B072F6EEAD19F0D2240B0 /* Thenable.swift */,
-				C57101628C8EDF06BC7342A48269104D /* when.m */,
-				793EAE17ACE0F873D75CC2FAF1AB96D7 /* when.swift */,
-			);
-			name = CorePromise;
-			sourceTree = "<group>";
-		};
-		EA68D727CBE29514A51539E05025D5E1 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				15B42CF2FA09282008A2E6844E15042E /* Info.plist */,
-				D388102D4167E26F5F588350B86F0E22 /* secp256k1_ios.modulemap */,
-				EEEB93F035012C9898D5A7532A30390A /* secp256k1_ios.xcconfig */,
-				781D6EBD207326333AF47A6E96B0513D /* secp256k1_ios-dummy.m */,
-				53F39FA42D6BF866A8B4E3829C876592 /* secp256k1_ios-prefix.pch */,
-				5C9AAD1576095621D68E0542F640A916 /* secp256k1_ios-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/secp256k1_ios";
-			sourceTree = "<group>";
-		};
-		F3AA583CC93045D4ECC14095048ED46E /* Foundation */ = {
-			isa = PBXGroup;
-			children = (
-				467FBA75EB54C769E993036F93727FE5 /* afterlife.swift */,
-				CA687D0E7D969684C006B6695B29A09A /* NSNotificationCenter+AnyPromise.h */,
-				C542891C63483A08B0BE169BA765C23A /* NSNotificationCenter+AnyPromise.m */,
-				3A669D344EFFFA9B94F1EA8373BFFC0E /* NSNotificationCenter+Promise.swift */,
-				EA3A83C2569B2AEEA18325963C025108 /* NSObject+Promise.swift */,
-				06689683269F5BCAE45322E0E2E5B38C /* NSTask+AnyPromise.h */,
-				0108F32F1505C2F0BAFD2DE18FBBECE2 /* NSTask+AnyPromise.m */,
-				604E46FD931FB989638FAD6E513EE901 /* NSURLSession+AnyPromise.h */,
-				F50E53C4909EEB420176F673A114DC38 /* NSURLSession+AnyPromise.m */,
-				27337216DDF15B18B0DB1B9B6F8B735C /* NSURLSession+Promise.swift */,
-				9914D1F2AE3E2341EE53A6C12D075E42 /* PMKFoundation.h */,
-				9321D523FB42C52138CF67410DF7C696 /* Process+Promise.swift */,
+				6E442F38E92C044663A7567FEC0218DB /* afterlife.swift */,
+				4510A3501569C7B4E5F4871FD8A5C827 /* NSNotificationCenter+AnyPromise.h */,
+				E59CC11F6ABC89EB9FA27553CAACD3C8 /* NSNotificationCenter+AnyPromise.m */,
+				F8B484180C55627FAAA803F7EE2DCEAB /* NSNotificationCenter+Promise.swift */,
+				7F4C3BB6186F689B7AE840596A84078B /* NSObject+Promise.swift */,
+				D9809E72EB7D02EF0C1B11F3C209AD5F /* NSTask+AnyPromise.h */,
+				0E62C76699E81E04C05E307B6A8AF068 /* NSTask+AnyPromise.m */,
+				BC2A88C86693001FC598E4F8FE65448A /* NSURLSession+AnyPromise.h */,
+				E10FEED15925304FB7969ECED0F6F76E /* NSURLSession+AnyPromise.m */,
+				E5A17FFD11532E99A0E9F025F03D166F /* NSURLSession+Promise.swift */,
+				937EB2F54E66DF5CEDFB6F004E8F1F2E /* PMKFoundation.h */,
+				7B719F0183CEE01B32C1F07763F2613A /* Process+Promise.swift */,
 			);
 			name = Foundation;
 			sourceTree = "<group>";
 		};
-		F6D3B32CAE7B2CC744FB92BFE806D159 /* Support Files */ = {
+		C062B03847835EC8EF560BE403125BAB /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				F3E8408039DE8DAE9AF68CB2494CA790 /* Info.plist */,
-				4F3B07290B1E3D40DD19152E4D8B12BC /* scrypt.modulemap */,
-				3C9463AB3BE7E04AEEBF396C3EEF0B92 /* scrypt.xcconfig */,
-				DC7523489901E7C1E4B20D907A43196A /* scrypt-dummy.m */,
-				50AAD3B6CB72AF6FBAAC9050B0812F9F /* scrypt-prefix.pch */,
-				831D4E4706C7D1131BA808C8CC6B2407 /* scrypt-umbrella.h */,
+				FCC646ABA7678EACF23DC0CA54F3A551 /* CryptoSwift.modulemap */,
+				426DF9C25A724BDBA5332E8E568A989D /* CryptoSwift.xcconfig */,
+				7041BC27C28AD00A274104896D8943E3 /* CryptoSwift-dummy.m */,
+				3A3622DDBC1CFFB098930D2CFBBC07C7 /* CryptoSwift-prefix.pch */,
+				92A558EE489C6417A46A979E39DCE1BD /* CryptoSwift-umbrella.h */,
+				87CD8CAF81719B2EC20415813486947E /* Info.plist */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/scrypt";
+			path = "../Target Support Files/CryptoSwift";
 			sourceTree = "<group>";
 		};
-		F896B1D4154D64E21FA7735B9A52C59C /* Support Files */ = {
+		C37E37BBBA7F60FA55B948C3958D61E7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A9267DC4FB6FB0541831558AA6F2EC0F /* Info.plist */,
-				21796FABFBA40AFBBDD92D9B31F55F52 /* SipHash.modulemap */,
-				82F8E69AD4D298893B6FC2CD10F86868 /* SipHash.xcconfig */,
-				14075CA0EEA75B672FB159A8787701FB /* SipHash-dummy.m */,
-				492E47E3E5D3546B33A83112EE9EEFBF /* SipHash-prefix.pch */,
-				07B6EF439601A747708F6DD2FF6242F2 /* SipHash-umbrella.h */,
+				5E669092646301ACE55600867B2D4DA6 /* Crashlytics.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CC635F913C88E151BF56D0A60385F400 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				D71ACEAF999AB82F8CDAFB02193EF4EF /* Alamofire */,
+				B3916E20DC5615889E9CC302CF0CC83F /* BigInt */,
+				A1C9EE2B9728C5B2B32088DBC0311C54 /* Crashlytics */,
+				701D794A27D07DCD8FE87E8EC3BB4C44 /* CryptoSwift */,
+				4C8A6B179AA4E76C202BBCBA889E8504 /* Fabric */,
+				897A3321253E4EE495EB38CC7E79307D /* PromiseKit */,
+				D6D4EC041F9F291BAC5584CF5C809657 /* QRCodeReader.swift */,
+				19480CB1024C73E32486E91584E6C941 /* Result */,
+				A01376561EAE237CF8F9BF23C6C5F58A /* scrypt */,
+				61585239C97BA3866332989DA49840CF /* secp256k1_ios */,
+				085509A7A9D33257C468D1B2099F3C81 /* SipHash */,
+				0A76D811D50CB6D8736790335E3893ED /* web3swift */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		CF0FC5307DBDC36DA8459B0F10F1C65E /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				8A1D530F1E6B73BA3641C9DA7D783CEC /* BigInt.modulemap */,
+				469AA552618E9C216A633389DEC44B18 /* BigInt.xcconfig */,
+				D9C692C08213B8DB7387F7930D1365D4 /* BigInt-dummy.m */,
+				1534BC96A3154081231B949A04C8E579 /* BigInt-prefix.pch */,
+				4647F04C7ED31642A5C97FFEB14C4FD0 /* BigInt-umbrella.h */,
+				0AF2E685B8E27662A8BFA0743A27C5E1 /* Info.plist */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/SipHash";
+			path = "../Target Support Files/BigInt";
+			sourceTree = "<group>";
+		};
+		D6D4EC041F9F291BAC5584CF5C809657 /* QRCodeReader.swift */ = {
+			isa = PBXGroup;
+			children = (
+				5F6AE0B6578FC38928FDAE2A1D7F1950 /* QRCodeReader.swift */,
+				D8669ED437B4269BEA0E9FA54AACDF9A /* QRCodeReaderResult.swift */,
+				E0B177EA78A9BB9FAC15ADA59CB21E85 /* QRCodeReaderView.swift */,
+				A8796A6C08F8592D9CE812BD9B184C87 /* QRCodeReaderViewContainer.swift */,
+				8B28B0A2B21362D0A9AD85EA2466BDC5 /* QRCodeReaderViewController.swift */,
+				04B551E8C7EDF19BDA8260EDB49E536F /* QRCodeReaderViewControllerBuilder.swift */,
+				4996D8E35AB40C6394A8C8149844B437 /* QRCodeReaderViewControllerDelegate.swift */,
+				AAEAD748EABB865472012722BBC282CA /* ReaderOverlayView.swift */,
+				2A9E9F05A9B792E0E91D36873C906C0A /* SwitchCameraButton.swift */,
+				F3AA68A9D6621F4FA5B468BAFEA1D19A /* ToggleTorchButton.swift */,
+				E2A37499E8860700BDC3F8DD058CDFBD /* Support Files */,
+			);
+			name = QRCodeReader.swift;
+			path = QRCodeReader.swift;
+			sourceTree = "<group>";
+		};
+		D71ACEAF999AB82F8CDAFB02193EF4EF /* Alamofire */ = {
+			isa = PBXGroup;
+			children = (
+				7832791EE18B0023B28AAAC9039EE90F /* AFError.swift */,
+				BE793F8B74E5CCD76899F63529F9CB04 /* Alamofire.swift */,
+				D018E84EED83CC3078FCCD3270F2ADAF /* DispatchQueue+Alamofire.swift */,
+				3DDF980766BE47F9321CB1912ACC7791 /* MultipartFormData.swift */,
+				736443A191D489AACD7786CE2779EE6A /* NetworkReachabilityManager.swift */,
+				939E4127DFDB5C703CBE8DC97714FD01 /* Notifications.swift */,
+				80EC6B707DF6C990C65CD05DA0301567 /* ParameterEncoding.swift */,
+				50FA1AD549AF9033EB1C6ECC3198AAD8 /* Request.swift */,
+				D46CC1978DC1AFE01C606CAE78F5EB25 /* Response.swift */,
+				2DD6BB50AD8EF2630AC60A823D4D8B38 /* ResponseSerialization.swift */,
+				58C2E683987F15936DEBBB1187F7DB51 /* Result.swift */,
+				3507236898BBAB32C5E17C54301D2439 /* ServerTrustPolicy.swift */,
+				3C843EBE82ACC990822A3F32C0639EBC /* SessionDelegate.swift */,
+				3CA16A9AE900F8E53C16B7639911CFB8 /* SessionManager.swift */,
+				5CC8D1E73F3D420CD00739B71C0703B8 /* TaskDelegate.swift */,
+				88B076EAAB85640AB48F8818F0C83657 /* Timeline.swift */,
+				EDD7A4E497D99E6792618A7AC28151C0 /* Validation.swift */,
+				73F1DF5F11D29BC1A267853CD2F05F10 /* Support Files */,
+			);
+			name = Alamofire;
+			path = Alamofire;
+			sourceTree = "<group>";
+		};
+		E2A37499E8860700BDC3F8DD058CDFBD /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				A45716CD51A52B4C4E37E747A142CC84 /* Info.plist */,
+				BE9A54A506A81E396702012E6290BB76 /* QRCodeReader.swift.modulemap */,
+				720C933C8917AAD3A9F20BCA98ACC3E6 /* QRCodeReader.swift.xcconfig */,
+				9A58C40C1A7DB1C8A734F1436A9490FA /* QRCodeReader.swift-dummy.m */,
+				3826BAA9DEB95CE66CFB35EEF51C5AAB /* QRCodeReader.swift-prefix.pch */,
+				3860EA4942855E49A62C829717D8ECF4 /* QRCodeReader.swift-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/QRCodeReader.swift";
+			sourceTree = "<group>";
+		};
+		F0F046EE1FB998A9E379C8FD1FF770B5 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				AAAC75383E246EA11843B677C63C9409 /* Info.plist */,
+				363E36802536D62CF12122E6F649C75D /* web3swift.modulemap */,
+				24FDF35724679F9043A665E71C7DE5AD /* web3swift.xcconfig */,
+				56F399204F0B76DF92B22D4221126C0B /* web3swift-dummy.m */,
+				0DBED1CDD8405F0862D2D9D5103C0F35 /* web3swift-prefix.pch */,
+				8C052F06433005A8A6C466DFD2D5C585 /* web3swift-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/web3swift";
 			sourceTree = "<group>";
 		};
 		FA8F8E5109E7FA0AB8DDDF65F8D3E8BD /* iOS */ = {
@@ -1579,82 +1744,18 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		FC902BF2403FD3379E3A4FAC7C527576 /* QRCodeReader.swift */ = {
+		FF0431ECE19ADFC65A11233E25AFB955 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				1BD0605F39212C4B999DCEC974A04FD8 /* QRCodeReader.swift */,
-				DDEEC3EBA384B1DDF7CE41B1E9B2E753 /* QRCodeReaderResult.swift */,
-				22EE51E952189926295F6C68F96A5523 /* QRCodeReaderView.swift */,
-				EAD2BAFEA6D37F1FA154D73188D93633 /* QRCodeReaderViewContainer.swift */,
-				8452179E7393B2FA7CE61DE683FF7D73 /* QRCodeReaderViewController.swift */,
-				9C1B25B4A57B80C024DAF4169CBD5738 /* QRCodeReaderViewControllerBuilder.swift */,
-				6DA62EB56D9502B656E1ED4F5FA1309E /* QRCodeReaderViewControllerDelegate.swift */,
-				BB5427CACBC2CF16837E0169F9898C09 /* ReaderOverlayView.swift */,
-				0B9450BA0F46F30E624483F51BD75FC1 /* SwitchCameraButton.swift */,
-				D51DD83364DA2F39BA950E45A16A9374 /* ToggleTorchButton.swift */,
-				9989E08DEF40977CB40DD3B99F95B14C /* Support Files */,
+				E62B49C2DEA24C2E79E33B758AFA3173 /* Info.plist */,
+				9A6F5312645A6EE3C6E58F47D7966B1F /* secp256k1_ios.modulemap */,
+				2EF4EC959306B2073A44F94FDD0ABBA9 /* secp256k1_ios.xcconfig */,
+				CE1FBDE0FB577612625318231AE57033 /* secp256k1_ios-dummy.m */,
+				5E686AD219F4FAF8FD26B1978591799E /* secp256k1_ios-prefix.pch */,
+				EAC3394F8A3EE59C59A9733F786B1306 /* secp256k1_ios-umbrella.h */,
 			);
-			name = QRCodeReader.swift;
-			path = QRCodeReader.swift;
-			sourceTree = "<group>";
-		};
-		FD5B625A6D244DDB4F700EE90D246A7E /* secp256k1_ios */ = {
-			isa = PBXGroup;
-			children = (
-				95DDFD2F47B41B96FBDF82BB79C4DA9F /* basic-config.h */,
-				F41A3CD9569B48AC734B519796E3C826 /* ecdsa.h */,
-				22A56A814792F2D067883D1148C235CE /* ecdsa_impl.h */,
-				BF2B2DA5A2561B9D5D3EAFD2BD989D64 /* eckey.h */,
-				8D8675FDA4BA5887BCD243BBD6DFAA05 /* eckey_impl.h */,
-				01EE091A06FF9586084A85DE0118B82C /* ecmult.h */,
-				644FF28E462665CF8CCAD2B89260E2AB /* ecmult_const.h */,
-				0F305D7EB0D67C4E7AA1642D028360C1 /* ecmult_const_impl.h */,
-				364EC788A63B85F05F96A9AACE2297AE /* ecmult_gen.h */,
-				3F1A12C496C6650091C82474F2B7E3E9 /* ecmult_gen_impl.h */,
-				FC852AFAFDAF21F5CDC00B08C2C9A229 /* ecmult_impl.h */,
-				5315E4C0E16806FBD1FEE84852B9A530 /* field.h */,
-				8AC375F014CAD55484ACDE4DD147AFAC /* field_10x26.h */,
-				BB13AC3AB426E3CB418672CB306B578B /* field_10x26_impl.h */,
-				52AAE0A2C0DDE48ACF55A256D9FF27DA /* field_5x52.h */,
-				EA37580FEA73153CDB7822F775F2AD8E /* field_5x52_asm_impl.h */,
-				5ABEFEDF0B2C2DAE50EE05965F4F2763 /* field_5x52_impl.h */,
-				7C267C22945AF26C33C325CE17070F06 /* field_5x52_int128_impl.h */,
-				824FFA281F8D34B24AFC5F28C8BCB67E /* field_impl.h */,
-				5CEDBC5518CC046F3FAF974A34A632F6 /* group.h */,
-				0DE789C6A63202C00A540AAFF2167D75 /* group_impl.h */,
-				7A06551A72C20599D9C7A45956FDBD26 /* hash.h */,
-				E92AE203A4F44CDC83748EE2EFD101CF /* hash_impl.h */,
-				DA3B8C705156CC5A9B627D04D4B8CE8A /* lax_der_parsing.c */,
-				6550B0F982A3AFAE39A3901DF284CFE4 /* lax_der_parsing.h */,
-				FE43D491122858F762CB98C49FA1B1B2 /* lax_der_privatekey_parsing.c */,
-				83F67535422CCA74B29B5F1CE1572FD2 /* lax_der_privatekey_parsing.h */,
-				EB94837CEC92402155A27E8CB6AAC010 /* libsecp256k1-config.h */,
-				86A8C87298BB26C969E9D9D731E59D54 /* main_impl.h */,
-				4B160E67829EADD2CCD679C0D5CD6E82 /* main_impl.h */,
-				2CBF4DD2E9E2CA1D86037728AD0551A2 /* num.h */,
-				37AD0340E0924A6901378EBD6C1DA73F /* num_gmp.h */,
-				8C551C86FF3B824BF8A787414B675472 /* num_gmp_impl.h */,
-				CA7B4CE9C4365DCA0228DF681C4E2948 /* num_impl.h */,
-				C43A02AA2A26B7A19A6767BC973BAD85 /* scalar.h */,
-				F58BDDA276A7BE795A0ABE5B5DB9B775 /* scalar_4x64.h */,
-				9109844DAD13D5EA4994FE47EAC8E7B6 /* scalar_4x64_impl.h */,
-				69520391266ED84E73AEEE018929DA2F /* scalar_8x32.h */,
-				5BCE86301701700B88CD7D4A5D2F8AD8 /* scalar_8x32_impl.h */,
-				6545781899C7A95A8BD49CD63992D424 /* scalar_impl.h */,
-				49891B8F292E9704D7BDC4E521EB5B88 /* scalar_low.h */,
-				7AC98C526C6420EA0CA8A80773A9D5CD /* scalar_low_impl.h */,
-				2820F060E279253421A0C56DAA72D99C /* scratch.h */,
-				1A8D61BB30BC74B566E0E813078D6D43 /* scratch_impl.h */,
-				AE2F6C3989B7DC36E54BF9F72856E6F1 /* secp256k1.c */,
-				0D98A342E3C4CE42E7EF1BF9FB8C2E41 /* secp256k1.h */,
-				601B089A77FC1BDA7B65D8B49C417791 /* secp256k1_ecdh.h */,
-				4317C6AE4C3DCDDA7D41BD55C5B5FC42 /* secp256k1_ios.h */,
-				6CC5946A47DB0731B068118DF7AD545B /* secp256k1_recovery.h */,
-				FD59E5D486F37BD5BE6262B1D48A811D /* util.h */,
-				EA68D727CBE29514A51539E05025D5E1 /* Support Files */,
-			);
-			name = secp256k1_ios;
-			path = secp256k1_ios;
+			name = "Support Files";
+			path = "../Target Support Files/secp256k1_ios";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1668,6 +1769,69 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		15760EC44BCD61478003D117780889F4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4DF280F691068BCD3DC0BB5631D4E85 /* Result-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A0C8C919AE57D43F9807B5F0B0B3A21 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				28B4E6A51F1638A431729AB5676C39B9 /* basic-config.h in Headers */,
+				30CB7ADC336A63AEDF18C84C6296DC90 /* ecdsa.h in Headers */,
+				EFD36171DFE635C56C71796AF7638EA8 /* ecdsa_impl.h in Headers */,
+				98037F51EA4A40D8EF580234D898372B /* eckey.h in Headers */,
+				BFA746D89DA91A8BB06B248A546C8EB4 /* eckey_impl.h in Headers */,
+				BD1514F70A0EC11706BCA55444999FC3 /* ecmult.h in Headers */,
+				6B0F4FAC46A2DBE742EF6D376BD03CAF /* ecmult_const.h in Headers */,
+				6DBF7CE6628CF9699C2C3BE302EED673 /* ecmult_const_impl.h in Headers */,
+				15302D6A0DBD3F5FC3056011D7BD8AC2 /* ecmult_gen.h in Headers */,
+				A063AF3BD1BDFFEE10689AAD1C93D80E /* ecmult_gen_impl.h in Headers */,
+				52C8DB9D1DC75CA87CB1700F1A7FDDA4 /* ecmult_impl.h in Headers */,
+				C990D358833D46262AC60E273E82144D /* field.h in Headers */,
+				EE13C80520635958874DC8A103A71791 /* field_10x26.h in Headers */,
+				E6CB085901BB43D49AC12B1FB6081269 /* field_10x26_impl.h in Headers */,
+				10A58D14F48DC82BE0A74505ACD12284 /* field_5x52.h in Headers */,
+				D0A150A0EC5E378336C4336372553DCE /* field_5x52_asm_impl.h in Headers */,
+				E2AC6A5E691454B1B4D9FFBE7B7C3FCD /* field_5x52_impl.h in Headers */,
+				8F57DA42FAE238F2F32B0F41A512B35E /* field_5x52_int128_impl.h in Headers */,
+				00E450DAE78DD6DC993B5DAF0DAE3E80 /* field_impl.h in Headers */,
+				D6234C479ACD00C74CBF73EE58473AA8 /* group.h in Headers */,
+				08020B2FAF536D0A83DBB3A2C1D933B9 /* group_impl.h in Headers */,
+				CF92FCDE194E8E24CCD8D08D893DC1AA /* hash.h in Headers */,
+				B703BCABA6EDA5544D5C9423FED8F477 /* hash_impl.h in Headers */,
+				E2D177E7B987881BB0AC79A55297C3C3 /* lax_der_parsing.h in Headers */,
+				4131579B2105A058790FFE28D7DDD7BA /* lax_der_privatekey_parsing.h in Headers */,
+				7E5C13FD0B0F002D59FB40E32118495D /* libsecp256k1-config.h in Headers */,
+				986B3829A2A2D6D9610048A002C39BC8 /* main_impl.h in Headers */,
+				15A90544B35843906C8B140ADBB41BD3 /* main_impl.h in Headers */,
+				A5BCBD5220F048342AFA4AD373E41A51 /* num.h in Headers */,
+				995E1CE5CC887714B3FBDBA9613DF04F /* num_gmp.h in Headers */,
+				901EB7C291CF64428DA601F703017F3F /* num_gmp_impl.h in Headers */,
+				776B9137AF2C7FD457A0C977F3A944FB /* num_impl.h in Headers */,
+				D83CF28C0050E1A5BAEB46C5F0703F66 /* scalar.h in Headers */,
+				912BC4160525A37A44C8E052CFEB362C /* scalar_4x64.h in Headers */,
+				B43388A0CF1145AE55F05907115B6DE7 /* scalar_4x64_impl.h in Headers */,
+				F2454DABD30D051691C20C1A5BB30DE0 /* scalar_8x32.h in Headers */,
+				B77D59DD389486DB6F147D720DF7EB41 /* scalar_8x32_impl.h in Headers */,
+				90102927AB42B3723962211F85E56805 /* scalar_impl.h in Headers */,
+				452051D6BA537B8695338A85D938E7C1 /* scalar_low.h in Headers */,
+				0A0702807C69D2A69C9033A16D16E97B /* scalar_low_impl.h in Headers */,
+				47216914F2A4679832458D0422D90110 /* scratch.h in Headers */,
+				14D78EDD36995D76475898CE85832A2C /* scratch_impl.h in Headers */,
+				68F27886042C31143EB3A22573DBDFB0 /* secp256k1.h in Headers */,
+				0EDF28FB31610CF486B81E0FECF1267F /* secp256k1_ecdh.h in Headers */,
+				98CB00EBFFCFBCAB10021D0E54135D9C /* secp256k1_ios-umbrella.h in Headers */,
+				ED472B0E1D15ED108378BC403DCC823E /* secp256k1_ios.h in Headers */,
+				8F354C0E7FF5211495179122C43BE627 /* secp256k1_recovery.h in Headers */,
+				5714E1F957F10FE8D3B68F6E58817ED8 /* util.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1D2E2951F6649C5063226E2D27D46394 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1676,39 +1840,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		33F167029F29AF4D71C3A65BF7EAE235 /* Headers */ = {
+		43CE77E8E9513B77FCF239530D21D28B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				44D5771020DDC133BA8AE2E560771DB9 /* web3swift-Bridging-Header.h in Headers */,
-				19B0977DB29904E6DE638F5373A9B54A /* web3swift-umbrella.h in Headers */,
-				A31AB7272EBF96F61B8FD0F77AD3EB7E /* web3swift.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		5B5CC3F0C124EA1B5E7EBE37746C0722 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				036DD11987B19189CB4D3F7D5C2E8362 /* Pods-DiveLane-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		73AE7C758DFCC26E03C513915E1C5815 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6B76D26A1BDE69761A89455E66A55A06 /* AnyPromise.h in Headers */,
-				B105CDBCFE2A0D83C1B09E755D979801 /* fwd.h in Headers */,
-				D28838224BE2A4676E92C7AD4DE160FE /* NSNotificationCenter+AnyPromise.h in Headers */,
-				720E059B6C1676C1BD20419F113E3E08 /* NSTask+AnyPromise.h in Headers */,
-				7CCB9C64A6DA4EDEF9D02F46E4FB1F8C /* NSURLSession+AnyPromise.h in Headers */,
-				231D94F4178EAA364509D93CCD051CE1 /* PMKFoundation.h in Headers */,
-				3A7AA8839AB9D27A1E568B8B50851F01 /* PMKUIKit.h in Headers */,
-				81A3C609852663C235928B34CAB031CE /* PromiseKit-umbrella.h in Headers */,
-				1FE37F8E4D182DBDC8C4F30AFD4757B4 /* PromiseKit.h in Headers */,
-				9939A142556FE3DE5C19FF9BDAABFCA7 /* UIView+AnyPromise.h in Headers */,
-				456B887CE57F5234CE8302917DC1E4C7 /* UIViewController+AnyPromise.h in Headers */,
+				C143D6A2E0FB9DC62AC4410417222EDA /* web3swift-Bridging-Header.h in Headers */,
+				A5DF522FA056143C10A11DF0E191F747 /* web3swift-umbrella.h in Headers */,
+				E466D230D23EFBBF8491C80407FDA362 /* web3swift.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1720,84 +1858,55 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9068A02619FB0D036A36600503C05B05 /* Headers */ = {
+		A6A607506FEAAC7C41268D3E5CF4E5FE /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				160FDDA9DD8EE18EB07873303FA53AE8 /* Cimpl.h in Headers */,
-				0B0BC8ECFE3E0D034F09A45BA825E43B /* scrypt-umbrella.h in Headers */,
-				A474A2F36899E23BEF7E72CA542AE16B /* scrypt.h in Headers */,
+				EF1461221681BCA12A4147900A704727 /* Alamofire-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BE6ED0B97E2861CDACA1A244A82E4DCA /* Headers */ = {
+		A7D5C3F9EE1793AE65253C1D6237B369 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E70470EF1B27F26E6E272126FD06EA88 /* QRCodeReader.swift-umbrella.h in Headers */,
+				5C93BF92E1D9CAE2A236D40F10EF5449 /* AnyPromise.h in Headers */,
+				165E24DD114893AB8FFB401FF99359E2 /* fwd.h in Headers */,
+				791173448CEA41EE22295C0898AAB52B /* NSNotificationCenter+AnyPromise.h in Headers */,
+				2692BCC812006C65B73E2F05579F3EB9 /* NSTask+AnyPromise.h in Headers */,
+				76DFD8D1994F9A566EE7137C454E6FF4 /* NSURLSession+AnyPromise.h in Headers */,
+				4BBEE38121FB5320986BC7890B7157D8 /* PMKFoundation.h in Headers */,
+				8DBD7AF8E01CC48A4EC81E5A5BE40DC0 /* PMKUIKit.h in Headers */,
+				DF652161003AED72FD7FC2FAAB5C5E39 /* PromiseKit-umbrella.h in Headers */,
+				9E476BF8E453403A0507887A100A6755 /* PromiseKit.h in Headers */,
+				6D513EE6B71A91EA3C364E543C8608BC /* UIView+AnyPromise.h in Headers */,
+				DAF528C5641C86802C739097EFA52C85 /* UIViewController+AnyPromise.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CB3F88FCC1E87EF3DF568D11373536CD /* Headers */ = {
+		C271800260F7046FA9E0E4AAEA4707B5 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F55E7AC1BB87A003556D9F217407EEC9 /* Result-umbrella.h in Headers */,
+				F0D4106B516969DDCAFCAC598DA3571E /* Cimpl.h in Headers */,
+				8DEAF2BC6728D500C85C317DBE4FADD2 /* scrypt-umbrella.h in Headers */,
+				67674EE7FC179283E6F0B4C4EDADC479 /* scrypt.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DE2245F18AAE8DC4829005A39AB37B6A /* Headers */ = {
+		F024A2B271042DE2ED5ACE0249519D7B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FFE76E41B1237942FE51F1B5D42CF077 /* basic-config.h in Headers */,
-				46AECBEE3C65BE052E92271C361181D3 /* ecdsa.h in Headers */,
-				74A4839D42C76D84E323A282E4B87B4B /* ecdsa_impl.h in Headers */,
-				CF6E429B7A206771952CA8D019D77E66 /* eckey.h in Headers */,
-				896297A6EC22A9600BD62BF36360D60C /* eckey_impl.h in Headers */,
-				D808DA8AF0A2365679F4A8AE8D470F3F /* ecmult.h in Headers */,
-				258BAACBB50FF93C7571AC4C3BE71BD7 /* ecmult_const.h in Headers */,
-				AD705D761EB2B3E3C6E19E29AE8018CC /* ecmult_const_impl.h in Headers */,
-				80C3394FE2538008263FA78F9E288416 /* ecmult_gen.h in Headers */,
-				6E8E66A9BC231CF690F365009629DE22 /* ecmult_gen_impl.h in Headers */,
-				0A87671A3BA0E230C5A2929DDF10585D /* ecmult_impl.h in Headers */,
-				17F13BC4520B04F0B4FBC069AE4E4A6D /* field.h in Headers */,
-				5E605FE6C0DD25A97BB34364CC609416 /* field_10x26.h in Headers */,
-				B8246291DF3891A83164B150E2E045C0 /* field_10x26_impl.h in Headers */,
-				78BD1B147DE9F65108D04D27A543A1C5 /* field_5x52.h in Headers */,
-				AA2A37518E86A0D2BF4FD2C5A6B82C6E /* field_5x52_asm_impl.h in Headers */,
-				EF356C7DDED17BC6D39CCB104D731668 /* field_5x52_impl.h in Headers */,
-				EE1315428CC555F10FF79748B7ABC406 /* field_5x52_int128_impl.h in Headers */,
-				760C04433110DCB2713D0CB160550719 /* field_impl.h in Headers */,
-				507737A3C7801DCFD0BF0574954ACB67 /* group.h in Headers */,
-				35B80D34CC0EA7C97ECC6B78EFCBDEA3 /* group_impl.h in Headers */,
-				4EDA34CBFEEAE6A37C2222C46EE940BF /* hash.h in Headers */,
-				A028F5CBAFFEDF5AF188D077ACF062B7 /* hash_impl.h in Headers */,
-				8D4878D23CC348B8C4302BE447DA9F8A /* lax_der_parsing.h in Headers */,
-				D57FC0427FCBBA88B4CBFF5E8EB47A2B /* lax_der_privatekey_parsing.h in Headers */,
-				4F8AA9FE9F4E3062335529D7D616A408 /* libsecp256k1-config.h in Headers */,
-				9F1FD140D7B763EFE5906D0006DC6DE9 /* main_impl.h in Headers */,
-				3B1551C7299DACE1B265C05440D44E6D /* main_impl.h in Headers */,
-				EA98D6932D6F09CAB0B6D5DC0032B73B /* num.h in Headers */,
-				3829A3D356E78A16CFC681BFC31988EC /* num_gmp.h in Headers */,
-				2B9040CE8F9995FE8E8EAA5022B33E95 /* num_gmp_impl.h in Headers */,
-				1374D153A4DF11A93393A7EB31034589 /* num_impl.h in Headers */,
-				93ECC8F5ECD659159576FCD7EC62A9BD /* scalar.h in Headers */,
-				F2F1B2110BA70AE5A85FA0A8519F0A20 /* scalar_4x64.h in Headers */,
-				DBFE03BADBBA9AA12AF693CBFCE7BC43 /* scalar_4x64_impl.h in Headers */,
-				B1096B673ECDFB6708A880F235F20281 /* scalar_8x32.h in Headers */,
-				1F0FFD9E2ECAC11C485C531C9E5172CC /* scalar_8x32_impl.h in Headers */,
-				78D128DBFC13C4593D650DA41F7E1123 /* scalar_impl.h in Headers */,
-				402F05E6635CCF2D45BC09F485F9FCAF /* scalar_low.h in Headers */,
-				31909E4DB572212059BC99B11853137C /* scalar_low_impl.h in Headers */,
-				273757501A417D274C80593F160D6339 /* scratch.h in Headers */,
-				4108BF7FD69977C4053C02D81AC9B194 /* scratch_impl.h in Headers */,
-				753B0D2648744254767333E94491CAF9 /* secp256k1.h in Headers */,
-				A33B905167DA52EF4F9447A372789E87 /* secp256k1_ecdh.h in Headers */,
-				F6B21DC973E10523629435FD699B1D18 /* secp256k1_ios-umbrella.h in Headers */,
-				D565D2C588403310E559D66C16B34801 /* secp256k1_ios.h in Headers */,
-				E89A64C0B4C4EEBC0BE855773078E283 /* secp256k1_recovery.h in Headers */,
-				C7759B28E1875D57C36804662699C75D /* util.h in Headers */,
+				A436E789CD2ED7B08FC9B0D42A7DBC05 /* QRCodeReader.swift-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F5C0B29CB74B555D0D7542829AF99004 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				27435128253747301FD929F5DBDCA4B5 /* Pods-DiveLane-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1820,35 +1929,17 @@
 			);
 			name = BigInt;
 			productName = BigInt;
-			productReference = 6138927DBD256234EEF7A0607055F4A5 /* BigInt.framework */;
+			productReference = 124CFE84E65BE490249D7B32E18CD4CB /* BigInt.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		2CF7A076E9162EBB8228CED135E7C18C /* Result */ = {
+		1C9AA7A4B8F37D8E5F4B43B22D1EF8A3 /* PromiseKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CF9B47EABDC4081F8981B500A2DA1363 /* Build configuration list for PBXNativeTarget "Result" */;
+			buildConfigurationList = F608F46F694DF62068D4455B9780A34D /* Build configuration list for PBXNativeTarget "PromiseKit" */;
 			buildPhases = (
-				CB3F88FCC1E87EF3DF568D11373536CD /* Headers */,
-				678C753654DD53322CEF2D51FD5DCA8C /* Sources */,
-				98EF3A34897D9731D9C0CD721BF3EB16 /* Frameworks */,
-				5F3E69C41B5E009759F03D7827532644 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Result;
-			productName = Result;
-			productReference = EC1CF885E556C543E884514C774065EA /* Result.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		303167748906E66A0A80381A36E3854B /* PromiseKit */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 75E1137F2D55F8FF45B7A9DAA708E38E /* Build configuration list for PBXNativeTarget "PromiseKit" */;
-			buildPhases = (
-				73AE7C758DFCC26E03C513915E1C5815 /* Headers */,
-				9B14F7B4F628340C3326BA321C8053DA /* Sources */,
-				AF214B39E3CD33D63E2CD18C114AEEDC /* Frameworks */,
-				5EF2CE40F85E17CB4755647FCB27874D /* Resources */,
+				A7D5C3F9EE1793AE65253C1D6237B369 /* Headers */,
+				D4FDB9877804876F61E7F411EF6BB181 /* Sources */,
+				B05A977C6F0AAB1146FC571FFA07EBEB /* Frameworks */,
+				23AB022ABA1F5F3918063DD95CAD759C /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1856,32 +1947,53 @@
 			);
 			name = PromiseKit;
 			productName = PromiseKit;
-			productReference = 3AEED4ACE3931CCC34F30F806D423E05 /* PromiseKit.framework */;
+			productReference = A23101FBFEBC11DD104C764E8151CD01 /* PromiseKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		3ED75BAF4B79F70F0C3833AFA7DF49AD /* web3swift */ = {
+		32E40FFD4C55CDF795FA4DF41F2DFF83 /* secp256k1_ios */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 3C80AB3B961D90D843CA153F965A2A92 /* Build configuration list for PBXNativeTarget "web3swift" */;
+			buildConfigurationList = D71A113F7FB614887B8B56A9A86FF3DF /* Build configuration list for PBXNativeTarget "secp256k1_ios" */;
 			buildPhases = (
-				33F167029F29AF4D71C3A65BF7EAE235 /* Headers */,
-				919D63B35AC8454A43F4EE6E1A68B23F /* Sources */,
-				36A4523547494987F793873748A028A7 /* Frameworks */,
-				E440591D9F8938BE6788EBDAF71BE58C /* Resources */,
+				1A0C8C919AE57D43F9807B5F0B0B3A21 /* Headers */,
+				04B8C98C8A0C9FE7E600E204575A9C4F /* Sources */,
+				FABDC971425BC3040587EB18F2DFC8A0 /* Frameworks */,
+				17359F77DBBB71FC44AABAB733680628 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				933DFFFBF5DBCD46647F96E0B920B534 /* PBXTargetDependency */,
-				7331D135A45C9F046BFA292F6A1DC5FC /* PBXTargetDependency */,
-				D2D981AB87C5C693E842B690891E8E2B /* PBXTargetDependency */,
-				EA475F78A3FB108D8188013329B24DD7 /* PBXTargetDependency */,
-				29B5090C6C8DE27E8E3FD54C75B13483 /* PBXTargetDependency */,
-				8DA7C1AFDC16D445F1279BB281610292 /* PBXTargetDependency */,
-				2EC11F60D0E56B8A9BE58A63DC4E1A51 /* PBXTargetDependency */,
 			);
-			name = web3swift;
-			productName = web3swift;
-			productReference = 3DA6E7C8123A0A5F0EF271F7C109EB9F /* web3swift.framework */;
+			name = secp256k1_ios;
+			productName = secp256k1_ios;
+			productReference = 03267157904456FAC7624F692E910B55 /* secp256k1_ios.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		344CDFE117E918BE14AF4DFD4188F26A /* Pods-DiveLane */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D0637060A33DEA8F8FFA737800C2EBA6 /* Build configuration list for PBXNativeTarget "Pods-DiveLane" */;
+			buildPhases = (
+				F5C0B29CB74B555D0D7542829AF99004 /* Headers */,
+				7739ED0B24817F2A05A5003E62AFD267 /* Sources */,
+				9E8EA1BE2E6CF96CEEF5C6B1F8A0444F /* Frameworks */,
+				7F4601A27F56A708D1EB537BBC97E5B7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0C1B5BDD155A9896415D047AA2BF9E8B /* PBXTargetDependency */,
+				1A925A06304C826DA3631C181DE22DB2 /* PBXTargetDependency */,
+				D3AD2D060BF235125486476D795092DF /* PBXTargetDependency */,
+				1843B5667C765D92B78E2DA8BE834CBB /* PBXTargetDependency */,
+				A4A159B4729C45B489E0BBAE81D4ED47 /* PBXTargetDependency */,
+				4BAEA8AE56D8766CB545AEFB67670F3A /* PBXTargetDependency */,
+				4CB86342D19DFDB7D542FDEB804E49E4 /* PBXTargetDependency */,
+				8C1877BFD461F37CC930F3438CD973E1 /* PBXTargetDependency */,
+				B156358436ED7612F9E958A900246E6D /* PBXTargetDependency */,
+				FF52D5706A5CE38ED7288B8DA389824E /* PBXTargetDependency */,
+			);
+			name = "Pods-DiveLane";
+			productName = "Pods-DiveLane";
+			productReference = 5AF3EA57EE4D3FFB37E2559DBF18CC6C /* Pods_DiveLane.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		4DACDE493E99BF92E5758A59F946A750 /* CryptoSwift */ = {
@@ -1899,52 +2011,7 @@
 			);
 			name = CryptoSwift;
 			productName = CryptoSwift;
-			productReference = 16F2514116997A54740C8C2A17DFF32A /* CryptoSwift.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		5BDFEE18D67B26A77BB56743C0BEEE8C /* Pods-DiveLane */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 75F63FEEE333FA09AADF0045B3600E41 /* Build configuration list for PBXNativeTarget "Pods-DiveLane" */;
-			buildPhases = (
-				5B5CC3F0C124EA1B5E7EBE37746C0722 /* Headers */,
-				A103981C1526C018B1935FBA687D8055 /* Sources */,
-				8EEA89C830F2D7EA4283377BE59AD0A1 /* Frameworks */,
-				4A8C536CBA9A373B9838F30DEE16E30C /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				C4ECCC8FE4D0AD205A431802158BF966 /* PBXTargetDependency */,
-				47521DCC00038E17823A6E1D4F7673A5 /* PBXTargetDependency */,
-				8621DBFFFF5F2ED1BF56149E9C612A78 /* PBXTargetDependency */,
-				8E834C402FF066E7DB0F5D2A15344751 /* PBXTargetDependency */,
-				7D6F705AA098296B7CECA8A356BFADD0 /* PBXTargetDependency */,
-				3CA6CCB6C3A853628E45B862B3AD2474 /* PBXTargetDependency */,
-				2E9C7A2ACE34B9F2D4DED5C507FAEF1A /* PBXTargetDependency */,
-				758097CC5506E7F86899B6D2262B0E26 /* PBXTargetDependency */,
-				FFAD29E0E17FE814BE29872DE984D296 /* PBXTargetDependency */,
-			);
-			name = "Pods-DiveLane";
-			productName = "Pods-DiveLane";
-			productReference = EBC92B4AF7864EC6077ECBDD382F325C /* Pods_DiveLane.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		66D012442239182123EE1AFADEB46664 /* secp256k1_ios */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 72AC1961BBF15FD368891C98E1ACC3E6 /* Build configuration list for PBXNativeTarget "secp256k1_ios" */;
-			buildPhases = (
-				DE2245F18AAE8DC4829005A39AB37B6A /* Headers */,
-				AC44E58630AF77FB17B60E50C6FB575B /* Sources */,
-				96BDDB24C568149F0A1CC93AD0E4BA5C /* Frameworks */,
-				AF68F7E1816FE8EEC36BBA210C6EDD12 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = secp256k1_ios;
-			productName = secp256k1_ios;
-			productReference = 637AA645BCF8A061118CCDB1207C8A69 /* secp256k1_ios.framework */;
+			productReference = 4036E3F8719C9DA138447CF896990DF0 /* CryptoSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		7FF8752D2607B0617A8EA59CB6F52DA7 /* SipHash */ = {
@@ -1962,36 +2029,42 @@
 			);
 			name = SipHash;
 			productName = SipHash;
-			productReference = E77FD6D23CC86CB4BDE310436BABA615 /* SipHash.framework */;
+			productReference = CEA2FA56B1D5976585D96D52DE483E3D /* SipHash.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		C70F37C85E26F4DC361D08DABC1D2308 /* scrypt */ = {
+		84B155C6F720EBFA5F1E099374CD6337 /* web3swift */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A528ABCD5D9EB3DE7A3EECD4E532BEA7 /* Build configuration list for PBXNativeTarget "scrypt" */;
+			buildConfigurationList = 291663543C7D8348FCBEB3E33D46B026 /* Build configuration list for PBXNativeTarget "web3swift" */;
 			buildPhases = (
-				9068A02619FB0D036A36600503C05B05 /* Headers */,
-				54D04575E4D9AEB417288960910515CA /* Sources */,
-				EC82EB0F5782563E9E7A2047AD5605F7 /* Frameworks */,
-				9BF3B91F7F29AB57E859473DF1904A2B /* Resources */,
+				43CE77E8E9513B77FCF239530D21D28B /* Headers */,
+				823A85F9B7166B88DEA21966DEC584C4 /* Sources */,
+				70BE950118F53DC9E9F48703255B415A /* Frameworks */,
+				F9B183954C735526D78AC533D9FE3E66 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				DD50DEA62CEAD260EF6A66E8CE483D95 /* PBXTargetDependency */,
+				60E2091204415F07C949EF61373581E2 /* PBXTargetDependency */,
+				9D014B3FF2AA4153D7B87DFDB2DEBEAE /* PBXTargetDependency */,
+				FD7BA297AF8D3F59C643881BFC8CF2FE /* PBXTargetDependency */,
+				577ED644D4AEB47DA30954091B36FD03 /* PBXTargetDependency */,
+				7242CE0A305444CC7CBB925C469E523A /* PBXTargetDependency */,
+				B37FF4F540F08EDA8CD4D12EA77150E4 /* PBXTargetDependency */,
+				2739807A9327694DEA5F73CD3FCD666E /* PBXTargetDependency */,
 			);
-			name = scrypt;
-			productName = scrypt;
-			productReference = 29B7168224886EC79F36144E6EF63DAA /* scrypt.framework */;
+			name = web3swift;
+			productName = web3swift;
+			productReference = 2737110627995C56D4523BEED35D20E7 /* web3swift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		F7A2AAC98407D026E81FB4955A54AFD5 /* QRCodeReader.swift */ = {
+		D1FD0E21E3FCF9A519A66590CEEB2A0F /* QRCodeReader.swift */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E3EB2D11C364DFB8BCE43D56ADCEA2C8 /* Build configuration list for PBXNativeTarget "QRCodeReader.swift" */;
+			buildConfigurationList = 067D56644BA4CE29BD8C9BB4ABDB74DB /* Build configuration list for PBXNativeTarget "QRCodeReader.swift" */;
 			buildPhases = (
-				BE6ED0B97E2861CDACA1A244A82E4DCA /* Headers */,
-				464B20B54BAF870D9DB8C3D09403E5E4 /* Sources */,
-				4ADBB089E0AEA24F21FB76041EFE327A /* Frameworks */,
-				E32AF4368A87BDD1BCE995B87EE2DBCD /* Resources */,
+				F024A2B271042DE2ED5ACE0249519D7B /* Headers */,
+				D0A2938F6AAB123F8AE564698A942D37 /* Sources */,
+				741B718A2BC8A59FFCD8B8927E40EE78 /* Frameworks */,
+				9618E6E28D4565D486127AA51930BA00 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1999,7 +2072,62 @@
 			);
 			name = QRCodeReader.swift;
 			productName = QRCodeReader.swift;
-			productReference = 17F02B1964D22AE7E6879024A6E2A0F8 /* QRCodeReader.framework */;
+			productReference = 87005B64D352C9CF9D7A7B052F8733B5 /* QRCodeReader.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		E6336E5011C07ED0B898E35CCE6962BC /* Result */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 083E21E1D5504DF0CFA520BD632D9F81 /* Build configuration list for PBXNativeTarget "Result" */;
+			buildPhases = (
+				15760EC44BCD61478003D117780889F4 /* Headers */,
+				45EE1AC956F0CA85AD96D513155D95B4 /* Sources */,
+				C465C6DA993B47AA16B0450E5E6C27DC /* Frameworks */,
+				D9ACC206258F69C90A9BC1467DB2410E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Result;
+			productName = Result;
+			productReference = 1A5215C0DD24304684C972DFFF7D02FC /* Result.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		E708490E977C6CAD49A6D120BFC83DFC /* scrypt */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 542923B6169AB32229C59B5B570D63AF /* Build configuration list for PBXNativeTarget "scrypt" */;
+			buildPhases = (
+				C271800260F7046FA9E0E4AAEA4707B5 /* Headers */,
+				9717839464A881B5DE2490AADE19DE82 /* Sources */,
+				AB4FAA8A9B5CF38AC2D4F4BD4B9EA1B8 /* Frameworks */,
+				485BE677BD5EF586E3A33E325D41BD91 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8B264ADA0FBF4CC6A5F4320220B00FD7 /* PBXTargetDependency */,
+			);
+			name = scrypt;
+			productName = scrypt;
+			productReference = 20097552F3A1817336DAA2939737D312 /* scrypt.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		E76458C58C9140B6A16D60547E68E80C /* Alamofire */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 427F0F003A1AD80AE00155AFCDEFAC20 /* Build configuration list for PBXNativeTarget "Alamofire" */;
+			buildPhases = (
+				A6A607506FEAAC7C41268D3E5CF4E5FE /* Headers */,
+				CC399CEC576B42C962CEB290481CAF95 /* Sources */,
+				6E8AF668A2161F7D6F680F721DB65D2D /* Frameworks */,
+				3DDB7E21141D7764AE4658D5B6AFF8C6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Alamofire;
+			productName = Alamofire;
+			productReference = 0F000ADE280FAB3A7DF2252A18CCF5ED /* Alamofire.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -2019,25 +2147,33 @@
 				en,
 			);
 			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = D7E726F612E66E49EC0F3C700D854B64 /* Products */;
+			productRefGroup = 84F42B9B27C7FD7D73B4BAC5290BEE4B /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				E76458C58C9140B6A16D60547E68E80C /* Alamofire */,
 				137411A4D3CCDCAE6EE1A79271E0889C /* BigInt */,
 				4DACDE493E99BF92E5758A59F946A750 /* CryptoSwift */,
-				5BDFEE18D67B26A77BB56743C0BEEE8C /* Pods-DiveLane */,
-				303167748906E66A0A80381A36E3854B /* PromiseKit */,
-				F7A2AAC98407D026E81FB4955A54AFD5 /* QRCodeReader.swift */,
-				2CF7A076E9162EBB8228CED135E7C18C /* Result */,
-				C70F37C85E26F4DC361D08DABC1D2308 /* scrypt */,
-				66D012442239182123EE1AFADEB46664 /* secp256k1_ios */,
+				344CDFE117E918BE14AF4DFD4188F26A /* Pods-DiveLane */,
+				1C9AA7A4B8F37D8E5F4B43B22D1EF8A3 /* PromiseKit */,
+				D1FD0E21E3FCF9A519A66590CEEB2A0F /* QRCodeReader.swift */,
+				E6336E5011C07ED0B898E35CCE6962BC /* Result */,
+				E708490E977C6CAD49A6D120BFC83DFC /* scrypt */,
+				32E40FFD4C55CDF795FA4DF41F2DFF83 /* secp256k1_ios */,
 				7FF8752D2607B0617A8EA59CB6F52DA7 /* SipHash */,
-				3ED75BAF4B79F70F0C3833AFA7DF49AD /* web3swift */,
+				84B155C6F720EBFA5F1E099374CD6337 /* web3swift */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		17359F77DBBB71FC44AABAB733680628 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1AF3324DAB2C8E0DD11A0DEC66CD5799 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2045,7 +2181,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4A8C536CBA9A373B9838F30DEE16E30C /* Resources */ = {
+		23AB022ABA1F5F3918063DD95CAD759C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3DDB7E21141D7764AE4658D5B6AFF8C6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		485BE677BD5EF586E3A33E325D41BD91 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2059,28 +2209,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5EF2CE40F85E17CB4755647FCB27874D /* Resources */ = {
+		7F4601A27F56A708D1EB537BBC97E5B7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5F3E69C41B5E009759F03D7827532644 /* Resources */ = {
+		9618E6E28D4565D486127AA51930BA00 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9BF3B91F7F29AB57E859473DF1904A2B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AF68F7E1816FE8EEC36BBA210C6EDD12 /* Resources */ = {
+		D9ACC206258F69C90A9BC1467DB2410E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2094,14 +2237,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E32AF4368A87BDD1BCE995B87EE2DBCD /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E440591D9F8938BE6788EBDAF71BE58C /* Resources */ = {
+		F9B183954C735526D78AC533D9FE3E66 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2111,6 +2247,17 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		04B8C98C8A0C9FE7E600E204575A9C4F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A2A6097FE8255EE90F1F6DE2BE700404 /* lax_der_parsing.c in Sources */,
+				9E78BD9CDC348617DFD8E0E4622A3320 /* lax_der_privatekey_parsing.c in Sources */,
+				79673D7F8AC2969E2BF8D3865AFA94A5 /* secp256k1.c in Sources */,
+				87A29EE8951867AFBFF86FC496FBB0A6 /* secp256k1_ios-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2BD29726F4F37EEF096F8ED056E45044 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2190,45 +2337,120 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		464B20B54BAF870D9DB8C3D09403E5E4 /* Sources */ = {
+		45EE1AC956F0CA85AD96D513155D95B4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1D66060E38DEFB248D31C71742F0C23E /* QRCodeReader.swift in Sources */,
-				A6E056C2FC1C6B76B21733779D5E2E46 /* QRCodeReader.swift-dummy.m in Sources */,
-				13EAB80B4DDBD51BA7416B5334398697 /* QRCodeReaderResult.swift in Sources */,
-				08DB593EDADE2DD7883C29B717618E39 /* QRCodeReaderView.swift in Sources */,
-				408B29D76F70B7F2EDF4CD122343EF2F /* QRCodeReaderViewContainer.swift in Sources */,
-				B1C9A2AD55BC278D37D9EE61630C852F /* QRCodeReaderViewController.swift in Sources */,
-				FEAC80B941FF2C804D997C2DF64765A6 /* QRCodeReaderViewControllerBuilder.swift in Sources */,
-				8A597DC225922DDE99468A6D330E41B2 /* QRCodeReaderViewControllerDelegate.swift in Sources */,
-				F6F92FC558F75F2BB7F688AF5645090E /* ReaderOverlayView.swift in Sources */,
-				A8F8960202BF10728388569A076CA5AF /* SwitchCameraButton.swift in Sources */,
-				64E3A4C3300E39EA19A090640D6E826D /* ToggleTorchButton.swift in Sources */,
+				40E1945A90EE5B5A7DC369B078E77E55 /* AnyError.swift in Sources */,
+				82B753C99B1998F9F8DD6C355D479880 /* NoError.swift in Sources */,
+				4173934A29B2F23DD9C85E5D4BF28CF9 /* Result-dummy.m in Sources */,
+				AFDA8D13E690A68FF8B9C923A97BD466 /* Result.swift in Sources */,
+				22534153749FF789988A709D3940AD70 /* ResultProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		54D04575E4D9AEB417288960910515CA /* Sources */ = {
+		7739ED0B24817F2A05A5003E62AFD267 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CED4D026286893716F44C6DF7B378DD7 /* BufferStorage.swift in Sources */,
-				0C8972E301C7F4F94D106F25C85FFC80 /* Cimpl.c in Sources */,
-				5BF4532CF26024B4289655217432FB72 /* Salsa.swift in Sources */,
-				479F92D977946F9AD0E3021E34880602 /* scrypt-dummy.m in Sources */,
-				DC206B17FBAFF044B6170E3826E327B1 /* Scrypt.swift in Sources */,
+				B60726775886A5470E682298753EC7FC /* Pods-DiveLane-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		678C753654DD53322CEF2D51FD5DCA8C /* Sources */ = {
+		823A85F9B7166B88DEA21966DEC584C4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B94EFD93F63D1FF0EC574918FACDE81E /* AnyError.swift in Sources */,
-				4A68E568539B9E22576A80460A0568AF /* NoError.swift in Sources */,
-				BE8889B9410CA6F7C7BF857151AAA2F6 /* Result-dummy.m in Sources */,
-				26CEEDFAC3FD4DFAD1D9C63E838DE21F /* Result.swift in Sources */,
-				CAA32151B569F35FB5C22AEBA894EE1C /* ResultProtocol.swift in Sources */,
+				48596848E4B2BB2477DC73C19FF0F1AC /* ABIv2.swift in Sources */,
+				4302B0FD5B5072F552F53D32D8D41713 /* ABIv2Decoding.swift in Sources */,
+				C71644D36145840EBC3987260942DA98 /* ABIv2Elements.swift in Sources */,
+				ED544BB12791C4C01CF6E523B96C8A62 /* ABIv2Encoding.swift in Sources */,
+				89128A20E6C8A058AF5679A461C06B74 /* ABIv2ParameterTypes.swift in Sources */,
+				6E8044AEEFA21B9B4D9718F4ADAA1DA8 /* ABIv2Parsing.swift in Sources */,
+				39AEF40199252CBF5FC30255F29478CA /* ABIv2TypeParser.swift in Sources */,
+				4D801F8EC17739B1E30D02078159997C /* AbstractKeystore.swift in Sources */,
+				F2A62A1DCE28373F93FD3AFCF0032E03 /* Array+Extension.swift in Sources */,
+				39B9B0C7235DC9EE84F094F507C8B224 /* Base58.swift in Sources */,
+				858EDADED0849F094E14AAA2D35EC642 /* BigUInt+ObjC.swift in Sources */,
+				74BCED1D4515510AEA3693709A473D84 /* BIP32HDNode.swift in Sources */,
+				25C5482FFA8F4EA9C80233389DBDDD85 /* BIP32Keystore.swift in Sources */,
+				3DD4CBC5260127158BA7EB3298168EA5 /* BIP32KeystoreJSONStructure.swift in Sources */,
+				BEB5FA1DF2DFA9A16C62C78FDBEB0F60 /* BIP39+WordLists.swift in Sources */,
+				61DF824D4F9281580C773CCC6ED413B2 /* BIP39.swift in Sources */,
+				C95D35DBE08B6B16472568FFB985931F /* BlockExplorer+GetTransactionHistory.swift in Sources */,
+				5F890D66CAE3B2F537033C8625DB8E19 /* BlockExplorer.swift in Sources */,
+				955032576272495217E22DC24330F5E4 /* BloomFilter.swift in Sources */,
+				A2359E6FA9743571581EA985032CECE6 /* ComparisonExtensions.swift in Sources */,
+				369E07C5AB03665A3DD4404972F6CF44 /* ContractABIv2.swift in Sources */,
+				6975328EAA470D8B97FD98F661BF3704 /* ContractProtocol.swift in Sources */,
+				A04364B389BAE99BCEA1F86596D404CF /* CryptoExtensions.swift in Sources */,
+				8066E1631B71F4FDBCCF460DF0484F46 /* Data+Extension.swift in Sources */,
+				9336E222FAD0A7FAE4B1F0FA18E81EA7 /* Dictionary+Extension.swift in Sources */,
+				FE108BCA4DE52F0967F3B3F9A81BF967 /* EIP67Code.swift in Sources */,
+				61075231F0ED9619CB4AC8837C9A09DD /* EIP681.swift in Sources */,
+				BDB125CFE9324E1F0A63709935117D1B /* ENS.swift in Sources */,
+				CC5FC7F90798330B302EA7B4AF4C49EB /* EthereumAddress+ObjC.swift in Sources */,
+				1705B469D469EC1581B939E2626A18DA /* EthereumAddress.swift in Sources */,
+				4526579B0116E5DD2556B4C55FAF4455 /* EthereumFilterEncodingExtensions.swift in Sources */,
+				9DC4AEECE8FF163D279EA1F988A68A63 /* EthereumKeystoreV3.swift in Sources */,
+				17131138F56BC6E14EC1CDD34235C9FD /* EthereumTransaction.swift in Sources */,
+				FEBFAC04167363A7EA8029822BB299D5 /* EventFiltering.swift in Sources */,
+				9C440121B1B2CB3D3D08D7221004F546 /* IBAN.swift in Sources */,
+				5E06B41CA2AA7D224F679FCDBC3B65D0 /* KeystoreManager+ObjC.swift in Sources */,
+				AA865C9CB2467587B15DBC682A081D0A /* KeystoreManager.swift in Sources */,
+				2E160B7C362227F145384C3C17323918 /* KeystoreV3JSONStructure.swift in Sources */,
+				B6858CAB7106EA19FCB3005E094BD31E /* LibSecp256k1Extension.swift in Sources */,
+				14F3A21C8F4DEFBE0C594B26EF4FFDA4 /* NameHash.swift in Sources */,
+				88E5A2C0115C47FCC0F0BC1EB2A709CC /* NativeTypesEncoding+Extensions.swift in Sources */,
+				DEB0BD83C9FD93BE95FB843D41E1FEFC /* NSRegularExpressionExtension.swift in Sources */,
+				EAD457174113111A9446C871DF80A290 /* PlainKeystore+ObjC.swift in Sources */,
+				200B9B56FBA48FE6906A130C24431419 /* PlainKeystore.swift in Sources */,
+				42FEEADB098E943F9485E9BB8BC473BC /* Promise+Batching.swift in Sources */,
+				BDDC293F508DEC2A9D3273D1C7EC6B44 /* Promise+HttpProvider.swift in Sources */,
+				51AD6B850E8F967A26394BEF6DBCC35C /* Promise+Web3+Contract+GetIndexedEvents.swift in Sources */,
+				2B1E44CBDD1017D5577B14AE21CD068D /* Promise+Web3+Eth+Call.swift in Sources */,
+				690B4BE64DCC9802E9908E9F3847C929 /* Promise+Web3+Eth+EstimateGas.swift in Sources */,
+				4ED4F6CF1B8A1EF0499AC7203572BD53 /* Promise+Web3+Eth+GetAccounts.swift in Sources */,
+				9F7513BDB75539D13F0D1BEE170F3889 /* Promise+Web3+Eth+GetBalance.swift in Sources */,
+				F5835978C09B666E35587CEDB171D57D /* Promise+Web3+Eth+GetBlockByHash.swift in Sources */,
+				DD730775E0AFFAD27A1EAB4372F9FB51 /* Promise+Web3+Eth+GetBlockByNumber.swift in Sources */,
+				AE4F66AFE7D779053B2D58EEEB3EAE11 /* Promise+Web3+Eth+GetBlockNumber.swift in Sources */,
+				08166CF14CD2924DA16C386BAB8C3867 /* Promise+Web3+Eth+GetGasPrice.swift in Sources */,
+				D3330EF1A553775BEC5A72B5C20F0E69 /* Promise+Web3+Eth+GetTransactionCount.swift in Sources */,
+				3F7BFFDD3A8601304CEF6BBF9B124C86 /* Promise+Web3+Eth+GetTransactionDetails.swift in Sources */,
+				047A0D63C193F5121712C49A69566C71 /* Promise+Web3+Eth+GetTransactionReceipt.swift in Sources */,
+				E4DBDFB182A70FBD2DF63EB85315BCCF /* Promise+Web3+Eth+SendRawTransaction.swift in Sources */,
+				4016BD78E12B885C061DC2926E93FE9A /* Promise+Web3+Eth+SendTransaction.swift in Sources */,
+				948A42776191ADF279EA54B47486240D /* Promise+Web3+Intermediate+Send.swift in Sources */,
+				F9CA45B6C064700E89542DF66C9290B7 /* Promise+Web3+Personal+Sign.swift in Sources */,
+				2E46D003F391554493DDAF4F1152057A /* Promise+Web3+Personal+UnlockAccount.swift in Sources */,
+				1850A3735865F68F0474EA40F62EE21D /* RIPEMD160+StackOveflow.swift in Sources */,
+				98C06B447E3A8A96B8B0B2BDEDFD33B0 /* RLP.swift in Sources */,
+				B1F5CCD9CAD4830DC4A9929384FBF546 /* String+Extension.swift in Sources */,
+				89FE93BB1568967A8E8518D0D58E3E4E /* TransactionSigner.swift in Sources */,
+				7719D7A7A72CF0E40F9F89906821C42F /* Web3+BrowserFunctions.swift in Sources */,
+				5919A71B89C3F5AA506DAB7F3D6798BC /* Web3+Contract.swift in Sources */,
+				E824C0A2F6DF39E7FB967C0E94C551A1 /* Web3+ERC20.swift in Sources */,
+				F854349B3765620110B7B718A7CD10F8 /* Web3+Eth+ObjC.swift in Sources */,
+				FCE6F0C6E44CEB492EE435F1E59C332C /* Web3+Eth.swift in Sources */,
+				7E644BB890A7580698FAA02B380F08F3 /* Web3+EventParser.swift in Sources */,
+				6626CB2A08C917C093B2264498488AB2 /* Web3+HttpProvider+ObjC.swift in Sources */,
+				189B682B8F3FCC98CDF5C9323ACD56B8 /* Web3+HttpProvider.swift in Sources */,
+				432BB99529E39113DC6EE0432EEC9663 /* Web3+Infura.swift in Sources */,
+				310C9BF056AB994B2375B2562996F56D /* Web3+Instance+ObjC.swift in Sources */,
+				FA4390D046D496FCAF883D359C752835 /* Web3+Instance.swift in Sources */,
+				47E2CFA66B02443586299818C8AFB954 /* Web3+JSONRPC.swift in Sources */,
+				F5DC5ADD3B52C79B705C8606FF26BFE4 /* Web3+Methods.swift in Sources */,
+				9AEEE54DCA29801E2228D95001454313 /* Web3+ObjC.swift in Sources */,
+				67E81553B67058901E26634B52225EF6 /* Web3+Options.swift in Sources */,
+				97C42E926597427B195C654502EDD194 /* Web3+Personal.swift in Sources */,
+				7109C06E96166F681B1950B6709F7A24 /* Web3+Protocols.swift in Sources */,
+				717BD63D3A6607AF9DC07F82D6725DFF /* Web3+Structures.swift in Sources */,
+				DC7CAB8E9A0A5DF69D861A9096AF2B0E /* Web3+TransactionIntermediate.swift in Sources */,
+				2527808B40692A8D1F95E47478560B99 /* Web3+Utils.swift in Sources */,
+				4D5CA24A2F318A927383D4984C766CC6 /* Web3+Wallet.swift in Sources */,
+				352F101124A05162CC7A023592F89976 /* Web3.swift in Sources */,
+				CAD31C705E326EE53F54CDB408182774 /* web3swift-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2262,103 +2484,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		919D63B35AC8454A43F4EE6E1A68B23F /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				4A733BAC015ACB5056CB0D8CBD7F69B1 /* ABIv2.swift in Sources */,
-				AE9893361AA98D8A605B9E8219A44E33 /* ABIv2Decoding.swift in Sources */,
-				95A614F4944FCBD7134BB7C405CDA69C /* ABIv2Elements.swift in Sources */,
-				3A29B014EA2BF3DBF9EEDEB0870AE370 /* ABIv2Encoding.swift in Sources */,
-				AF40B6D3EA64E4492E39A28BE9711295 /* ABIv2ParameterTypes.swift in Sources */,
-				9DABC6A806D00241695EE106356E0724 /* ABIv2Parsing.swift in Sources */,
-				C14CE845EB0E0282DB7FCED8A4695A09 /* ABIv2TypeParser.swift in Sources */,
-				422EFA06EB78BB58512A7A991A381D70 /* AbstractKeystore.swift in Sources */,
-				3CEA14322993381ACA64215A5DDB6105 /* Array+Extension.swift in Sources */,
-				A5B2AC85E75DBD4083EA59AC1B4DF221 /* Base58.swift in Sources */,
-				1EED58F062A3C4CD640300B780F23434 /* BigUInt+ObjC.swift in Sources */,
-				D1AAB08A2C4753E0BDA67647B824A4E6 /* BIP32HDNode.swift in Sources */,
-				2C7AA6751A2BF7F5C65E7EDEFA595863 /* BIP32Keystore.swift in Sources */,
-				3492ED003DC8973858B66BF7D35BFABC /* BIP32KeystoreJSONStructure.swift in Sources */,
-				3E080572BF08164EC9E2E1BAD5F6C299 /* BIP39+WordLists.swift in Sources */,
-				61C9A5A0D07A83163E761331C3A09235 /* BIP39.swift in Sources */,
-				8F016113B2425520977300A66BD4B319 /* BlockExplorer+GetTransactionHistory.swift in Sources */,
-				BA1FFC8A0A7634CC89B9BEC68B4BD625 /* BlockExplorer.swift in Sources */,
-				307CB0FCD98B435E4EF121EC3A15138C /* BloomFilter.swift in Sources */,
-				AC98E762CE8A8342E41A7DE3328D3FD6 /* ComparisonExtensions.swift in Sources */,
-				BDF04540F5EADFC8D25324EA6002C7E4 /* ContractABIv2.swift in Sources */,
-				667314B78F8C2F2303C1DB976BD6DAFF /* ContractProtocol.swift in Sources */,
-				2938FF66785FC4AE2B3ED4EE1553D10E /* CryptoExtensions.swift in Sources */,
-				B1A2E4BB5C1D2ACB8E9E408D9B11C4E5 /* Data+Extension.swift in Sources */,
-				B15A649BB6CC3D089394A30F991C601D /* Dictionary+Extension.swift in Sources */,
-				997F1730D7482B9BB12D1B62E227F555 /* EIP67Code.swift in Sources */,
-				E0D532279F8653339587E76E19281271 /* EIP681.swift in Sources */,
-				A1B6A33DDDF1D1B9148786E477B24720 /* ENS.swift in Sources */,
-				8398BCDCAC56F650C191A1E73A124B46 /* EthereumAddress+ObjC.swift in Sources */,
-				FC471107E99701BA9650C2F5C28F7E2D /* EthereumAddress.swift in Sources */,
-				DB82D0A6866EA4EFEFC9EB995DEFE411 /* EthereumFilterEncodingExtensions.swift in Sources */,
-				AD5370BA4B0DFB62DDB3A45E8A47DCEE /* EthereumKeystoreV3.swift in Sources */,
-				1F659F98C15E25C3A72D24E71FD3A7BC /* EthereumTransaction.swift in Sources */,
-				AB35A003CE80631DC7854597271FE080 /* EventFiltering.swift in Sources */,
-				5F974AECB341D9D3803F41DBDA5C0C9C /* IBAN.swift in Sources */,
-				631BFF10DF9676CB1DE10D503E054BDE /* KeystoreManager+ObjC.swift in Sources */,
-				CCA302A346FC3E32900A3DA14F00B8BA /* KeystoreManager.swift in Sources */,
-				8E5F935FFC0DDAAF57F9B7642740BF8B /* KeystoreV3JSONStructure.swift in Sources */,
-				5942E74FF6759CDFBB626CD3367F1B60 /* LibSecp256k1Extension.swift in Sources */,
-				41FA65AF886C76B05AA97BC919A53C46 /* NameHash.swift in Sources */,
-				04006266093ACBC0A638A0142C4D1AF6 /* NativeTypesEncoding+Extensions.swift in Sources */,
-				B97CC7C4BD5082A8E2B47BD5FD47DCB1 /* NSRegularExpressionExtension.swift in Sources */,
-				474541CC65BD4B1D9D073E3D50F180BD /* PlainKeystore+ObjC.swift in Sources */,
-				50D441DA78ACDC136B35A4ADA9987B77 /* PlainKeystore.swift in Sources */,
-				DBE0389A6B1CB1210587983AD0732F93 /* Promise+Batching.swift in Sources */,
-				936376510B6C0560978BE9B6F9D4D5EF /* Promise+HttpProvider.swift in Sources */,
-				A551E86CC0AF1D873DA6C4A0A44CC9DB /* Promise+Web3+Contract+GetIndexedEvents.swift in Sources */,
-				50BB41FBE680000496F3A72BEC0F144E /* Promise+Web3+Eth+Call.swift in Sources */,
-				D055E971D83B4EF001F8B0C05D40B422 /* Promise+Web3+Eth+EstimateGas.swift in Sources */,
-				CBA19A08C5BD25AFFEA9E7711B2CF8F2 /* Promise+Web3+Eth+GetAccounts.swift in Sources */,
-				C73B1942236DECB83572F647B7BE40CE /* Promise+Web3+Eth+GetBalance.swift in Sources */,
-				93518324F84C9EDB96CC06AB53DB330C /* Promise+Web3+Eth+GetBlockByHash.swift in Sources */,
-				D51B75A3AF47900D622D415FC229E027 /* Promise+Web3+Eth+GetBlockByNumber.swift in Sources */,
-				FDB4C331D31F49C704C2FDEE5E613066 /* Promise+Web3+Eth+GetBlockNumber.swift in Sources */,
-				2DBE17D3917228ABDD4392497CD81BF8 /* Promise+Web3+Eth+GetGasPrice.swift in Sources */,
-				AB8F7E4426BB517219518FEA4D2265B2 /* Promise+Web3+Eth+GetTransactionCount.swift in Sources */,
-				6B9A7F86588E7293BD3C8C6E37D6F386 /* Promise+Web3+Eth+GetTransactionDetails.swift in Sources */,
-				DA5B470FFD674D60426F8B3343B5DE76 /* Promise+Web3+Eth+GetTransactionReceipt.swift in Sources */,
-				61A35075CF29BE7234EB91A1F892806B /* Promise+Web3+Eth+SendRawTransaction.swift in Sources */,
-				9CF67C923B79810A9C5DDD8C4949E9D0 /* Promise+Web3+Eth+SendTransaction.swift in Sources */,
-				83A1C6B7C6C91FF8750AE385830E8208 /* Promise+Web3+Intermediate+Send.swift in Sources */,
-				FA1E1886C06F92EC076CBDA943C753D6 /* Promise+Web3+Personal+Sign.swift in Sources */,
-				93EC97477C57529354AF8E85681D30BF /* Promise+Web3+Personal+UnlockAccount.swift in Sources */,
-				2CA9E21123C847948518E282093C61C9 /* RIPEMD160+StackOveflow.swift in Sources */,
-				E1E2F0F5B7C9AEBCB8A473C861A0D35E /* RLP.swift in Sources */,
-				C91C350A9136FD770560AC2D13DC54DE /* String+Extension.swift in Sources */,
-				EC69A07ACD1A82BBDC82246FF91B5001 /* TransactionSigner.swift in Sources */,
-				E4FC94AE7C56A7ED8954F5AD1E4FE46B /* Web3+BrowserFunctions.swift in Sources */,
-				31ADAD2ED18511966F4E763ECCE3118B /* Web3+Contract.swift in Sources */,
-				552B747D85A3E5CEFF08F76D9A7474AC /* Web3+ERC20.swift in Sources */,
-				EB10FB84711D4D320F14A9D18A016CDE /* Web3+Eth+ObjC.swift in Sources */,
-				9345F9F5DAF71289D5E677F5726BBB60 /* Web3+Eth.swift in Sources */,
-				DA15C3B185171BD6E5F97A26C60FED2B /* Web3+EventParser.swift in Sources */,
-				6A1F54D649142296CAAD7C90C9B613F9 /* Web3+HttpProvider+ObjC.swift in Sources */,
-				9C21F8BD616A0A6F9B42A9A9C4B2C0BC /* Web3+HttpProvider.swift in Sources */,
-				4F6D1DF6893D882990C7029249F8AFBF /* Web3+Infura.swift in Sources */,
-				AC6A460135DB70A59434BBFA75968FC0 /* Web3+Instance+ObjC.swift in Sources */,
-				A1F0EC742D51427285C0F99AE1D57B79 /* Web3+Instance.swift in Sources */,
-				8B0AF3D31FD7DE15D88A8BE59CC2FC85 /* Web3+JSONRPC.swift in Sources */,
-				BE364FD8788A8019FE5F488F0F2360E8 /* Web3+Methods.swift in Sources */,
-				1D18F2ACBCAEBB8A02EC4133AE07F517 /* Web3+ObjC.swift in Sources */,
-				7E3BAFF52BF90BE22DE8B7A31CB5BB53 /* Web3+Options.swift in Sources */,
-				0717C597991F5FBC8CE91AD8636AC665 /* Web3+Personal.swift in Sources */,
-				DB30A42F75E28F7EFA26F29028A696A2 /* Web3+Protocols.swift in Sources */,
-				B42395E589CAC70B11F08A597F10C9B7 /* Web3+Structures.swift in Sources */,
-				1683DAE42C36CCB9ECE24588628B039E /* Web3+TransactionIntermediate.swift in Sources */,
-				8B1FE06FFB95E1BE525603F1D9955034 /* Web3+Utils.swift in Sources */,
-				0FEB4BA2D6EE420C6B205CA6493C6E43 /* Web3+Wallet.swift in Sources */,
-				D1485BEE11C35FCE70AE3DF82ECD7B4C /* Web3.swift in Sources */,
-				A68206C6C54CD653154FD56ACFB1DE48 /* web3swift-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		92881122437CB3C21DE6947CADDF0A60 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2371,100 +2496,154 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9B14F7B4F628340C3326BA321C8053DA /* Sources */ = {
+		9717839464A881B5DE2490AADE19DE82 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7FBBE87CC46C371F2BE114C62A365F11 /* after.m in Sources */,
-				1C1237D0FB45A6ECDE25172AF2878F8F /* after.swift in Sources */,
-				0AECF16DDD9CAC98AC49FE7EF5FC85F4 /* afterlife.swift in Sources */,
-				AA65AD8A2647B7C8B13EE94715797770 /* AnyPromise.m in Sources */,
-				C771193C744CC0069CB1661CDE5C802D /* AnyPromise.swift in Sources */,
-				32BEA4678DE3E5B0462ECE11BECFC674 /* Box.swift in Sources */,
-				C403A8648896F5F7AD57ADE45FD25551 /* Catchable.swift in Sources */,
-				BECE178E35105E0FFB592CD9AEC591FA /* Configuration.swift in Sources */,
-				2631A7A57C311AA166F1E8ACDABCEBBF /* CustomStringConvertible.swift in Sources */,
-				6530675BA2CE2AF68B6ABC63A2AC2A48 /* Deprecations.swift in Sources */,
-				1AB4A0A4A8A746C9B892D15E445A3389 /* dispatch_promise.m in Sources */,
-				56C1BF6238EB4EE0364750506A13B1C6 /* Error.swift in Sources */,
-				48A6422D0964B4423600F7087EB579E8 /* firstly.swift in Sources */,
-				2FA185075E31AA6157B1CD9E388B33FF /* Guarantee.swift in Sources */,
-				A1CC8159BD821983537482D11A59411B /* hang.m in Sources */,
-				C40F08B54CA428A4D6A5196AB70AB370 /* hang.swift in Sources */,
-				759FB72F29405B421C53962F0F326098 /* join.m in Sources */,
-				F77CB59BF3A7FE0E4B364AE760E2D69E /* NSNotificationCenter+AnyPromise.m in Sources */,
-				4858803CFB9E79B9F1CA5DB45E9BFD62 /* NSNotificationCenter+Promise.swift in Sources */,
-				E03BD5674EE0D0937519FD3B55F2BBCB /* NSObject+Promise.swift in Sources */,
-				E80977D7F30E52B0A151AA3284FA0EA6 /* NSTask+AnyPromise.m in Sources */,
-				1B924C2342742E52ECF00A6DCABCBB37 /* NSURLSession+AnyPromise.m in Sources */,
-				8F25704823E74D4F7324445281286FE0 /* NSURLSession+Promise.swift in Sources */,
-				AC75879C79F55A175E7954CD3AE3D0EE /* Process+Promise.swift in Sources */,
-				5C4480ABDB905606FE04DE6062A912AF /* Promise.swift in Sources */,
-				86B72C362BAA2E77E8DB73120A057020 /* PromiseKit-dummy.m in Sources */,
-				ED7B7C502B11EAF1580EAE8236F1D010 /* race.m in Sources */,
-				3944B8F5749A1FE5EBC6D68B6EAA5636 /* race.swift in Sources */,
-				B0430DB0D1A212B1729DB5D7D247DD08 /* Resolver.swift in Sources */,
-				A8F867298C864CB03A598DB2B8D4A3A3 /* Thenable.swift in Sources */,
-				20A72431C84CF630A969A52D154F717A /* UIView+AnyPromise.m in Sources */,
-				338AED3F46DE8A9A6C2C2C57D9ED8ACE /* UIView+Promise.swift in Sources */,
-				80AF40E9EB7BAABF622776E7EE2FD256 /* UIViewController+AnyPromise.m in Sources */,
-				CF5CB139ED7F2044717593D9043A0ED7 /* UIViewPropertyAnimator+Promise.swift in Sources */,
-				E32D48366A58DE25C17441CC89C3B2F0 /* when.m in Sources */,
-				B4DEABFCC90E8C5C59125B49A4EBCB7D /* when.swift in Sources */,
+				01F1BB5AE9C9FD00910D95054BA3AE1B /* BufferStorage.swift in Sources */,
+				B4945EB6B680B4FE40DFBBA3B4E70C0F /* Cimpl.c in Sources */,
+				22FBB963C8F71C0D438D9284D74003AE /* Salsa.swift in Sources */,
+				3FD3AC619466F2C5C030C275E5FBFD1A /* scrypt-dummy.m in Sources */,
+				CB305592B499886BBD819BAFFEC2245D /* Scrypt.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A103981C1526C018B1935FBA687D8055 /* Sources */ = {
+		CC399CEC576B42C962CEB290481CAF95 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1BD471AEF71B89434B36F63FF9CA4064 /* Pods-DiveLane-dummy.m in Sources */,
+				BE4BA1EDE444A770F834605F4B65348E /* AFError.swift in Sources */,
+				D4C3899574E9D5DF5E5DA52310560BCC /* Alamofire-dummy.m in Sources */,
+				4E1A913EFB404FB11524718FF0298EFE /* Alamofire.swift in Sources */,
+				DBE6E2E4D205545E7988CFA5057C31D6 /* DispatchQueue+Alamofire.swift in Sources */,
+				FF9C7BC64DB23D2CED48197DE67F0335 /* MultipartFormData.swift in Sources */,
+				B77705737566AE83ED7E448923D7FA60 /* NetworkReachabilityManager.swift in Sources */,
+				500C8EDA60C07B0F127C7FC385E17D38 /* Notifications.swift in Sources */,
+				796177DE2762F24DAC16A709FD954838 /* ParameterEncoding.swift in Sources */,
+				965DACF3DC02857ECBE66C5CBA3DA5D4 /* Request.swift in Sources */,
+				52237C35642089F77DD4D723CEB25737 /* Response.swift in Sources */,
+				5EE5FED83B90A606A763CF1114D1D6FB /* ResponseSerialization.swift in Sources */,
+				F9EA61D484CC15FDDAB0D8C0D26D7949 /* Result.swift in Sources */,
+				6BEA14EC335E07C7063CD1383C0C443C /* ServerTrustPolicy.swift in Sources */,
+				1FC3FD39157C2FFFF3869A1300730086 /* SessionDelegate.swift in Sources */,
+				7068E8A7DDC1424EE8F24BC77E8746F4 /* SessionManager.swift in Sources */,
+				36FF8853CB34A9297AFAA8F5F7456324 /* TaskDelegate.swift in Sources */,
+				B424F524BBBE34E685129945993809A8 /* Timeline.swift in Sources */,
+				58A9719584AFA2D108D9E5C585A79329 /* Validation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AC44E58630AF77FB17B60E50C6FB575B /* Sources */ = {
+		D0A2938F6AAB123F8AE564698A942D37 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43D4B2F276FEFEC71562763C71EC4B0B /* lax_der_parsing.c in Sources */,
-				C6899540FF3A564EC36C0F5C8B803F7C /* lax_der_privatekey_parsing.c in Sources */,
-				1BCB9DD16356988A63930EE16C54EB64 /* secp256k1.c in Sources */,
-				EF63D72E24508A3F66501BDD4AA9E6C5 /* secp256k1_ios-dummy.m in Sources */,
+				07AD36BB4CEFE9208E337716C4B0A860 /* QRCodeReader.swift in Sources */,
+				BF3B3667BEDED5E979A4D30043B0C65D /* QRCodeReader.swift-dummy.m in Sources */,
+				739FE69AD413F5EC6D7A0B6CBCA36968 /* QRCodeReaderResult.swift in Sources */,
+				D0AD4F096F2C952FB827283A1E3C6407 /* QRCodeReaderView.swift in Sources */,
+				DB932EBD83F5AC0528C88D3708AB239C /* QRCodeReaderViewContainer.swift in Sources */,
+				C35FC2CAA12EEC4254D722CBE07F9E83 /* QRCodeReaderViewController.swift in Sources */,
+				85165F01416D8F5A5DAA80BBFBBBAE1C /* QRCodeReaderViewControllerBuilder.swift in Sources */,
+				252B1CFFD30EEEA350E6AD243D63414D /* QRCodeReaderViewControllerDelegate.swift in Sources */,
+				301EE9FBEE4A993A4C76C137ABD426A3 /* ReaderOverlayView.swift in Sources */,
+				D89B9A01F381C5D8386EA90FFF15C6E7 /* SwitchCameraButton.swift in Sources */,
+				CD629CC9DC61557B57F9728AE2EC57F9 /* ToggleTorchButton.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D4FDB9877804876F61E7F411EF6BB181 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7E4895C66B5EFA4A944F8E0302D49E19 /* after.m in Sources */,
+				D7CC4B991421163CC89AAE744074033F /* after.swift in Sources */,
+				A5854512E9A95A355810514E30034C1D /* afterlife.swift in Sources */,
+				BFE36D2DD6CF7DD04BB1BB1E1AA17564 /* AnyPromise.m in Sources */,
+				023904EB2AD527013067710B19463BD5 /* AnyPromise.swift in Sources */,
+				4C5FCFDE211A11AF01E44A0D1F74645A /* Box.swift in Sources */,
+				655B7373FA724E80DBF802D07B1BD68E /* Catchable.swift in Sources */,
+				01ADF8FEF4DF28905B2F70A9FBE5D1B7 /* Configuration.swift in Sources */,
+				66EACB1311A561A97A89DAC9CD38D293 /* CustomStringConvertible.swift in Sources */,
+				051E0DE7AC9BBE760F701E5472D220D3 /* Deprecations.swift in Sources */,
+				5CA1C6A73D09962F6596979CA3ADE64B /* dispatch_promise.m in Sources */,
+				5C43F79B94C6F6221B999CBCF5B2BBE2 /* Error.swift in Sources */,
+				E3A6B2EFFEEB0D63342BE773E35B7613 /* firstly.swift in Sources */,
+				C34917429A6F19D2B2FB285E7AD39BA1 /* Guarantee.swift in Sources */,
+				63A223833D2742F61675DD880B77D824 /* hang.m in Sources */,
+				7490339F96117697EDDB4CD81AC1A8E6 /* hang.swift in Sources */,
+				F242996490BC1DB2FEE2EB78AFD9EE13 /* join.m in Sources */,
+				1704C51E944C91C566E9ADE2AE5523B4 /* NSNotificationCenter+AnyPromise.m in Sources */,
+				F945087BB7909A6A01BE0658CAB5A013 /* NSNotificationCenter+Promise.swift in Sources */,
+				54BC8601AC0925470765411361F5C869 /* NSObject+Promise.swift in Sources */,
+				2B207C79219F8FC6771FC8499423F40E /* NSTask+AnyPromise.m in Sources */,
+				DF619245645A2412DDAFEADBECE520F2 /* NSURLSession+AnyPromise.m in Sources */,
+				A4256B5442606F51A40029AB6906C98B /* NSURLSession+Promise.swift in Sources */,
+				CA5050CE99378FD06459D795FD59971B /* Process+Promise.swift in Sources */,
+				3F767BF3B4D36825ACC636684D6761F0 /* Promise.swift in Sources */,
+				BBE610284DED27F26B953AF9A9E25E0D /* PromiseKit-dummy.m in Sources */,
+				792EC6F4DB546922DD52D46D8523483C /* race.m in Sources */,
+				F59CE65ADE4353A52F9316E6F0F4D541 /* race.swift in Sources */,
+				FC6375EF65F586FCFDF63C3CBD1B30CB /* Resolver.swift in Sources */,
+				062CF63F7C8BA7187034E313A85F18AE /* Thenable.swift in Sources */,
+				38419A5DAF2E880B7883784CFA2FDCE2 /* UIView+AnyPromise.m in Sources */,
+				B12AC1415BDCCDDD1D6EEAB56467CF55 /* UIView+Promise.swift in Sources */,
+				341896E79DAE50466B354002773EBD8F /* UIViewController+AnyPromise.m in Sources */,
+				2A0A446FDE9C20B00ABED6AAEF4D66CD /* UIViewPropertyAnimator+Promise.swift in Sources */,
+				A534168E127BE842705C6148A8F522E0 /* when.m in Sources */,
+				2B3E5D56DF7BC0A8F5EC634A6F4082BD /* when.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		29B5090C6C8DE27E8E3FD54C75B13483 /* PBXTargetDependency */ = {
+		0C1B5BDD155A9896415D047AA2BF9E8B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = SipHash;
-			target = 7FF8752D2607B0617A8EA59CB6F52DA7 /* SipHash */;
-			targetProxy = 0A4EC11D0E56665855E79F832BD5523E /* PBXContainerItemProxy */;
+			name = Alamofire;
+			target = E76458C58C9140B6A16D60547E68E80C /* Alamofire */;
+			targetProxy = 41C4CBC2259B5CB77167C1D04B3CF780 /* PBXContainerItemProxy */;
 		};
-		2E9C7A2ACE34B9F2D4DED5C507FAEF1A /* PBXTargetDependency */ = {
+		1843B5667C765D92B78E2DA8BE834CBB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = scrypt;
-			target = C70F37C85E26F4DC361D08DABC1D2308 /* scrypt */;
-			targetProxy = EA10A671767DF4FEBB0072E1BEE9A125 /* PBXContainerItemProxy */;
+			name = PromiseKit;
+			target = 1C9AA7A4B8F37D8E5F4B43B22D1EF8A3 /* PromiseKit */;
+			targetProxy = 207E64C251DF0422512B72A0455FCC12 /* PBXContainerItemProxy */;
 		};
-		2EC11F60D0E56B8A9BE58A63DC4E1A51 /* PBXTargetDependency */ = {
+		1A925A06304C826DA3631C181DE22DB2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BigInt;
+			target = 137411A4D3CCDCAE6EE1A79271E0889C /* BigInt */;
+			targetProxy = D64CC56D19627E119942DE28E4BA1341 /* PBXContainerItemProxy */;
+		};
+		2739807A9327694DEA5F73CD3FCD666E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = secp256k1_ios;
-			target = 66D012442239182123EE1AFADEB46664 /* secp256k1_ios */;
-			targetProxy = EB1C268B148714FBC899190875F55A93 /* PBXContainerItemProxy */;
+			target = 32E40FFD4C55CDF795FA4DF41F2DFF83 /* secp256k1_ios */;
+			targetProxy = 5A44B36ADD52645ACBC8C7DC792BC5B8 /* PBXContainerItemProxy */;
 		};
-		3CA6CCB6C3A853628E45B862B3AD2474 /* PBXTargetDependency */ = {
+		4BAEA8AE56D8766CB545AEFB67670F3A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Result;
+			target = E6336E5011C07ED0B898E35CCE6962BC /* Result */;
+			targetProxy = C15C087EB5B719D99BC9EDAF7D0F18F4 /* PBXContainerItemProxy */;
+		};
+		4CB86342D19DFDB7D542FDEB804E49E4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SipHash;
 			target = 7FF8752D2607B0617A8EA59CB6F52DA7 /* SipHash */;
-			targetProxy = 3320856BDDB3B8FC631B9197BC0F3425 /* PBXContainerItemProxy */;
+			targetProxy = 75BECA4ACE5F992A3800555500F7FFFD /* PBXContainerItemProxy */;
 		};
-		47521DCC00038E17823A6E1D4F7673A5 /* PBXTargetDependency */ = {
+		577ED644D4AEB47DA30954091B36FD03 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = CryptoSwift;
-			target = 4DACDE493E99BF92E5758A59F946A750 /* CryptoSwift */;
-			targetProxy = 27677CBF19E248690987A98F05DF010F /* PBXContainerItemProxy */;
+			name = Result;
+			target = E6336E5011C07ED0B898E35CCE6962BC /* Result */;
+			targetProxy = 026F18226FF47CED6CF4C0EB22D192BA /* PBXContainerItemProxy */;
+		};
+		60E2091204415F07C949EF61373581E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BigInt;
+			target = 137411A4D3CCDCAE6EE1A79271E0889C /* BigInt */;
+			targetProxy = C53873A0B3680AD230A5BBAFCC4F7A3C /* PBXContainerItemProxy */;
 		};
 		61069262FD5BCD41F1C291E25CAF599B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2472,84 +2651,72 @@
 			target = 7FF8752D2607B0617A8EA59CB6F52DA7 /* SipHash */;
 			targetProxy = C6C17D0086F8D9E70B8AF619657FF2BC /* PBXContainerItemProxy */;
 		};
-		7331D135A45C9F046BFA292F6A1DC5FC /* PBXTargetDependency */ = {
+		7242CE0A305444CC7CBB925C469E523A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SipHash;
+			target = 7FF8752D2607B0617A8EA59CB6F52DA7 /* SipHash */;
+			targetProxy = 4CDF31E448E66C4116679E964AD4A2DD /* PBXContainerItemProxy */;
+		};
+		8B264ADA0FBF4CC6A5F4320220B00FD7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CryptoSwift;
 			target = 4DACDE493E99BF92E5758A59F946A750 /* CryptoSwift */;
-			targetProxy = 0E2892B5FFA632E668E8418208290F0E /* PBXContainerItemProxy */;
+			targetProxy = BF7F3669B64C047A101458F54D7E440A /* PBXContainerItemProxy */;
 		};
-		758097CC5506E7F86899B6D2262B0E26 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = secp256k1_ios;
-			target = 66D012442239182123EE1AFADEB46664 /* secp256k1_ios */;
-			targetProxy = A3D5DAD1763E4E6923BF969C818CE266 /* PBXContainerItemProxy */;
-		};
-		7D6F705AA098296B7CECA8A356BFADD0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Result;
-			target = 2CF7A076E9162EBB8228CED135E7C18C /* Result */;
-			targetProxy = 0AC7F1D783910203391A096BB44AFE48 /* PBXContainerItemProxy */;
-		};
-		8621DBFFFF5F2ED1BF56149E9C612A78 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PromiseKit;
-			target = 303167748906E66A0A80381A36E3854B /* PromiseKit */;
-			targetProxy = 1350D05DA9F9A6D6B1A2D654E8453D08 /* PBXContainerItemProxy */;
-		};
-		8DA7C1AFDC16D445F1279BB281610292 /* PBXTargetDependency */ = {
+		8C1877BFD461F37CC930F3438CD973E1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = scrypt;
-			target = C70F37C85E26F4DC361D08DABC1D2308 /* scrypt */;
-			targetProxy = F7D5BE6737E68DA11F3206217531CA1E /* PBXContainerItemProxy */;
+			target = E708490E977C6CAD49A6D120BFC83DFC /* scrypt */;
+			targetProxy = D5513F654B044E90CD48552BAB2707B9 /* PBXContainerItemProxy */;
 		};
-		8E834C402FF066E7DB0F5D2A15344751 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = QRCodeReader.swift;
-			target = F7A2AAC98407D026E81FB4955A54AFD5 /* QRCodeReader.swift */;
-			targetProxy = 8A28B4E981EFFD5D5775CCA48395951C /* PBXContainerItemProxy */;
-		};
-		933DFFFBF5DBCD46647F96E0B920B534 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BigInt;
-			target = 137411A4D3CCDCAE6EE1A79271E0889C /* BigInt */;
-			targetProxy = 6AE1E210BA97E2EEEF9C377464884C0B /* PBXContainerItemProxy */;
-		};
-		C4ECCC8FE4D0AD205A431802158BF966 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BigInt;
-			target = 137411A4D3CCDCAE6EE1A79271E0889C /* BigInt */;
-			targetProxy = DD0CC46BE29772CB5FBF7B15CB37F15E /* PBXContainerItemProxy */;
-		};
-		D2D981AB87C5C693E842B690891E8E2B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PromiseKit;
-			target = 303167748906E66A0A80381A36E3854B /* PromiseKit */;
-			targetProxy = 9BC5CA57C59D9CF1B13BE5C4DB9C5433 /* PBXContainerItemProxy */;
-		};
-		DD50DEA62CEAD260EF6A66E8CE483D95 /* PBXTargetDependency */ = {
+		9D014B3FF2AA4153D7B87DFDB2DEBEAE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CryptoSwift;
 			target = 4DACDE493E99BF92E5758A59F946A750 /* CryptoSwift */;
-			targetProxy = 77C40BC9CBE387BBDEC10012A0969514 /* PBXContainerItemProxy */;
+			targetProxy = 945D1A49FEE51625B075FCF160E24E7C /* PBXContainerItemProxy */;
 		};
-		EA475F78A3FB108D8188013329B24DD7 /* PBXTargetDependency */ = {
+		A4A159B4729C45B489E0BBAE81D4ED47 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Result;
-			target = 2CF7A076E9162EBB8228CED135E7C18C /* Result */;
-			targetProxy = D8ED359090D8E6308F80F32E1CE50A8F /* PBXContainerItemProxy */;
+			name = QRCodeReader.swift;
+			target = D1FD0E21E3FCF9A519A66590CEEB2A0F /* QRCodeReader.swift */;
+			targetProxy = 1295E2C5375438A1EA3E9B89CD31A1B9 /* PBXContainerItemProxy */;
 		};
-		FFAD29E0E17FE814BE29872DE984D296 /* PBXTargetDependency */ = {
+		B156358436ED7612F9E958A900246E6D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = secp256k1_ios;
+			target = 32E40FFD4C55CDF795FA4DF41F2DFF83 /* secp256k1_ios */;
+			targetProxy = FD583C21E0767AC03D6C2C062CFCA80E /* PBXContainerItemProxy */;
+		};
+		B37FF4F540F08EDA8CD4D12EA77150E4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = scrypt;
+			target = E708490E977C6CAD49A6D120BFC83DFC /* scrypt */;
+			targetProxy = 6B38882EB21F2C8D8330F7B7F14F9ABB /* PBXContainerItemProxy */;
+		};
+		D3AD2D060BF235125486476D795092DF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CryptoSwift;
+			target = 4DACDE493E99BF92E5758A59F946A750 /* CryptoSwift */;
+			targetProxy = 0216552AFC35B881CD5BA3173367F6B3 /* PBXContainerItemProxy */;
+		};
+		FD7BA297AF8D3F59C643881BFC8CF2FE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PromiseKit;
+			target = 1C9AA7A4B8F37D8E5F4B43B22D1EF8A3 /* PromiseKit */;
+			targetProxy = 563B47278A0942617A66E48057B56B48 /* PBXContainerItemProxy */;
+		};
+		FF52D5706A5CE38ED7288B8DA389824E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = web3swift;
-			target = 3ED75BAF4B79F70F0C3833AFA7DF49AD /* web3swift */;
-			targetProxy = AE770EAC881F63B06508DC2630595F5A /* PBXContainerItemProxy */;
+			target = 84B155C6F720EBFA5F1E099374CD6337 /* web3swift */;
+			targetProxy = 1BF4983F7D57B18FFD797186BBF98793 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		0057089AF8F947CD4D03AA6509FFC9C8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 08FEE5DD01F91DFDFB96333BB631B52F /* CryptoSwift.xcconfig */;
+			baseConfigurationReference = 426DF9C25A724BDBA5332E8E568A989D /* CryptoSwift.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2585,9 +2752,44 @@
 			};
 			name = Release;
 		};
+		01F77B74955626F69D0E3B75A610BDAE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2EF4EC959306B2073A44F94FDD0ABBA9 /* secp256k1_ios.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/secp256k1_ios/secp256k1_ios-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/secp256k1_ios/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/secp256k1_ios/secp256k1_ios.modulemap";
+				PRODUCT_MODULE_NAME = secp256k1_ios;
+				PRODUCT_NAME = secp256k1_ios;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		0E1CA0B2DC857760761B5911DE879D37 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 82F8E69AD4D298893B6FC2CD10F86868 /* SipHash.xcconfig */;
+			baseConfigurationReference = E13BDB16C6FC7A33FA7D98F0EB669D59 /* SipHash.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2623,9 +2825,9 @@
 			};
 			name = Release;
 		};
-		16D0EAFCC4CEA1F4901988E9BB1CAAF1 /* Debug */ = {
+		11501F35A84F5D7DD09552223A70AEB4 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3C9463AB3BE7E04AEEBF396C3EEF0B92 /* scrypt.xcconfig */;
+			baseConfigurationReference = 056672AFA34A366E30A383A25346F6F6 /* Alamofire.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2636,8 +2838,46 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/scrypt/scrypt-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/scrypt/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Alamofire/Alamofire-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Alamofire/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/Alamofire/Alamofire.modulemap";
+				PRODUCT_MODULE_NAME = Alamofire;
+				PRODUCT_NAME = Alamofire;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		14F49199D3CC1E3B81464D3C5F935647 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 24FDF35724679F9043A665E71C7DE5AD /* web3swift.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/web3swift/web3swift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/web3swift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2645,23 +2885,99 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "Target Support Files/scrypt/scrypt.modulemap";
-				PRODUCT_MODULE_NAME = scrypt;
-				PRODUCT_NAME = scrypt;
+				MODULEMAP_FILE = "Target Support Files/web3swift/web3swift.modulemap";
+				PRODUCT_MODULE_NAME = web3swift;
+				PRODUCT_NAME = web3swift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.1;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		18FA6289DA10BA2B8C8740866D86E9C2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 720C933C8917AAD3A9F20BCA98ACC3E6 /* QRCodeReader.swift.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/QRCodeReader.swift/QRCodeReader.swift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/QRCodeReader.swift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/QRCodeReader.swift/QRCodeReader.swift.modulemap";
+				PRODUCT_MODULE_NAME = QRCodeReader;
+				PRODUCT_NAME = QRCodeReader;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.1;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
+		1AB7B0610028743B8C8B8A7166ADFFE2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 228079A457478E0D94A95DD898CE5D74 /* Result.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Result/Result-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Result/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/Result/Result.modulemap";
+				PRODUCT_MODULE_NAME = Result;
+				PRODUCT_NAME = Result;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		1AD77FEABD116A48BB2C7546DD5189DF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 82F8E69AD4D298893B6FC2CD10F86868 /* SipHash.xcconfig */;
+			baseConfigurationReference = E13BDB16C6FC7A33FA7D98F0EB669D59 /* SipHash.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2697,7 +3013,7 @@
 		};
 		1FA8669733BEDD7BBE2B5F79C2FFD6DF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F1F1DE46A800C6C6ACF22F28AC4A9E55 /* BigInt.xcconfig */;
+			baseConfigurationReference = 469AA552618E9C216A633389DEC44B18 /* BigInt.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2733,7 +3049,45 @@
 			};
 			name = Release;
 		};
-		2A88E0C397165D2CC4151BB5EF9E3E77 /* Release */ = {
+		386B844D06A5C35F1E8F677124FB0F8E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 28B3CB87BCF1CA2665B162967F951CA8 /* scrypt.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/scrypt/scrypt-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/scrypt/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/scrypt/scrypt.modulemap";
+				PRODUCT_MODULE_NAME = scrypt;
+				PRODUCT_NAME = scrypt;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.1;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		4D965340994D321A83197A205B0723C1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C24C3C440F9FB14B2CAF631D7C6CF3D9 /* Pods-DiveLane.release.xcconfig */;
 			buildSettings = {
@@ -2773,9 +3127,9 @@
 			};
 			name = Release;
 		};
-		2AD0DAEFB2B084E43E601375030D32E1 /* Release */ = {
+		5B5F3D56B70FB451B5DA18DCE290A04A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B3CFB7A375AE11906A99E54EE63DE37D /* QRCodeReader.swift.xcconfig */;
+			baseConfigurationReference = 2EF4EC959306B2073A44F94FDD0ABBA9 /* secp256k1_ios.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2786,23 +3140,21 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/QRCodeReader.swift/QRCodeReader.swift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/QRCodeReader.swift/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/secp256k1_ios/secp256k1_ios-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/secp256k1_ios/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "Target Support Files/QRCodeReader.swift/QRCodeReader.swift.modulemap";
-				PRODUCT_MODULE_NAME = QRCodeReader;
-				PRODUCT_NAME = QRCodeReader;
+				MODULEMAP_FILE = "Target Support Files/secp256k1_ios/secp256k1_ios.modulemap";
+				PRODUCT_MODULE_NAME = secp256k1_ios;
+				PRODUCT_NAME = secp256k1_ios;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -2811,81 +3163,9 @@
 			};
 			name = Release;
 		};
-		36C53686462EB409C25AFED3AFFF2F49 /* Debug */ = {
+		5FFBE88AFE3EB1D3D9317E7F0E40B582 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B3CFB7A375AE11906A99E54EE63DE37D /* QRCodeReader.swift.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/QRCodeReader.swift/QRCodeReader.swift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/QRCodeReader.swift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/QRCodeReader.swift/QRCodeReader.swift.modulemap";
-				PRODUCT_MODULE_NAME = QRCodeReader;
-				PRODUCT_NAME = QRCodeReader;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		55AEA2E47B7BEE4513E0FCD92DBDD630 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0602B443D4A90F45A146F9DF0317539F /* PromiseKit.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PromiseKit/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
-				PRODUCT_MODULE_NAME = PromiseKit;
-				PRODUCT_NAME = PromiseKit;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		5AA4687AC371136C1B0F3BDB8DE09826 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3C9463AB3BE7E04AEEBF396C3EEF0B92 /* scrypt.xcconfig */;
+			baseConfigurationReference = 28B3CB87BCF1CA2665B162967F951CA8 /* scrypt.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2911,15 +3191,13 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
 		60DAF49CA7A9F362148D49C3C3123B2A /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2985,9 +3263,9 @@
 			};
 			name = Debug;
 		};
-		6B58B970FA89C62260ECAC051331AD7E /* Release */ = {
+		642D853BF5417D21248BD08A8121C397 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EEEB93F035012C9898D5A7532A30390A /* secp256k1_ios.xcconfig */;
+			baseConfigurationReference = 720C933C8917AAD3A9F20BCA98ACC3E6 /* QRCodeReader.swift.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2998,21 +3276,23 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/secp256k1_ios/secp256k1_ios-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/secp256k1_ios/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/QRCodeReader.swift/QRCodeReader.swift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/QRCodeReader.swift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "Target Support Files/secp256k1_ios/secp256k1_ios.modulemap";
-				PRODUCT_MODULE_NAME = secp256k1_ios;
-				PRODUCT_NAME = secp256k1_ios;
+				MODULEMAP_FILE = "Target Support Files/QRCodeReader.swift/QRCodeReader.swift.modulemap";
+				PRODUCT_MODULE_NAME = QRCodeReader;
+				PRODUCT_NAME = QRCodeReader;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -3021,11 +3301,10 @@
 			};
 			name = Release;
 		};
-		95709AAE2A614AA06746949C0AABE592 /* Debug */ = {
+		7CED9DAE291F2AEE5E8CD3FAE56530B8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E1E917490C4838EEA38C4DFB3D31C25B /* Pods-DiveLane.debug.xcconfig */;
+			baseConfigurationReference = 228079A457478E0D94A95DD898CE5D74 /* Result.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3035,25 +3314,23 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-DiveLane/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Result/Result-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Result/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-DiveLane/Pods-DiveLane.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				MODULEMAP_FILE = "Target Support Files/Result/Result.modulemap";
+				PRODUCT_MODULE_NAME = Result;
+				PRODUCT_NAME = Result;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -3062,7 +3339,7 @@
 		};
 		9B9BAF4A00A81F55CCBF702EF75A95D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 08FEE5DD01F91DFDFB96333BB631B52F /* CryptoSwift.xcconfig */;
+			baseConfigurationReference = 426DF9C25A724BDBA5332E8E568A989D /* CryptoSwift.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3096,9 +3373,9 @@
 			};
 			name = Debug;
 		};
-		9EA5AE8B6FE433F7BEB76F17396B1538 /* Debug */ = {
+		A248860FC512D02CEB6B77967405B5C6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0A82428D09BC54E0EE0DA1B4F9A0D20A /* web3swift.xcconfig */;
+			baseConfigurationReference = A072AF0ACC773EF3B8B92B46FEC26400 /* PromiseKit.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3109,82 +3386,8 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/web3swift/web3swift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/web3swift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/web3swift/web3swift.modulemap";
-				PRODUCT_MODULE_NAME = web3swift;
-				PRODUCT_NAME = web3swift;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.1;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		A67A26674D797D31BE32D03798456392 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0A82428D09BC54E0EE0DA1B4F9A0D20A /* web3swift.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/web3swift/web3swift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/web3swift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/web3swift/web3swift.modulemap";
-				PRODUCT_MODULE_NAME = web3swift;
-				PRODUCT_NAME = web3swift;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.1;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		BB96DA7328FD9B6D9E5AF5F02A4CC254 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C3DC8E36D9095B4B0AA882FF480B7161 /* Result.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Result/Result-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Result/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/PromiseKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3192,14 +3395,89 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "Target Support Files/Result/Result.modulemap";
-				PRODUCT_MODULE_NAME = Result;
-				PRODUCT_NAME = Result;
+				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
+				PRODUCT_MODULE_NAME = PromiseKit;
+				PRODUCT_NAME = PromiseKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BC26ACE7A8E469B7CB4DF93AB98ED9BA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 056672AFA34A366E30A383A25346F6F6 /* Alamofire.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Alamofire/Alamofire-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Alamofire/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/Alamofire/Alamofire.modulemap";
+				PRODUCT_MODULE_NAME = Alamofire;
+				PRODUCT_NAME = Alamofire;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		C2515876189680EFF27B6D630974AD4A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E1E917490C4838EEA38C4DFB3D31C25B /* Pods-DiveLane.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-DiveLane/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-DiveLane/Pods-DiveLane.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -3267,7 +3545,7 @@
 		};
 		CEC35C8F09F0E632AE273BC4716D7AAC /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F1F1DE46A800C6C6ACF22F28AC4A9E55 /* BigInt.xcconfig */;
+			baseConfigurationReference = 469AA552618E9C216A633389DEC44B18 /* BigInt.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3301,9 +3579,9 @@
 			};
 			name = Debug;
 		};
-		DE30D0A5850A6DDEFCCBD94E1E96D979 /* Release */ = {
+		E651976B70BE86932EA87F2B9AD68978 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C3DC8E36D9095B4B0AA882FF480B7161 /* Result.xcconfig */;
+			baseConfigurationReference = 24FDF35724679F9043A665E71C7DE5AD /* web3swift.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3314,46 +3592,8 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Result/Result-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Result/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/Result/Result.modulemap";
-				PRODUCT_MODULE_NAME = Result;
-				PRODUCT_NAME = Result;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		EAC3556ACB9158C696605F6DF7FED0F7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = EEEB93F035012C9898D5A7532A30390A /* secp256k1_ios.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/secp256k1_ios/secp256k1_ios-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/secp256k1_ios/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/web3swift/web3swift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/web3swift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3361,22 +3601,23 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "Target Support Files/secp256k1_ios/secp256k1_ios.modulemap";
-				PRODUCT_MODULE_NAME = secp256k1_ios;
-				PRODUCT_NAME = secp256k1_ios;
+				MODULEMAP_FILE = "Target Support Files/web3swift/web3swift.modulemap";
+				PRODUCT_MODULE_NAME = web3swift;
+				PRODUCT_NAME = web3swift;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
-		F99145997395F97BC5A56174A456C867 /* Release */ = {
+		FDD442AB08C54E819E788A01F9F01229 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0602B443D4A90F45A146F9DF0317539F /* PromiseKit.xcconfig */;
+			baseConfigurationReference = A072AF0ACC773EF3B8B92B46FEC26400 /* PromiseKit.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3415,11 +3656,38 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		067D56644BA4CE29BD8C9BB4ABDB74DB /* Build configuration list for PBXNativeTarget "QRCodeReader.swift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				18FA6289DA10BA2B8C8740866D86E9C2 /* Debug */,
+				642D853BF5417D21248BD08A8121C397 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		083E21E1D5504DF0CFA520BD632D9F81 /* Build configuration list for PBXNativeTarget "Result" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7CED9DAE291F2AEE5E8CD3FAE56530B8 /* Debug */,
+				1AB7B0610028743B8C8B8A7166ADFFE2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		18A84A1682CD37CFA0F42453F6BF95C9 /* Build configuration list for PBXNativeTarget "SipHash" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1AD77FEABD116A48BB2C7546DD5189DF /* Debug */,
 				0E1CA0B2DC857760761B5911DE879D37 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		291663543C7D8348FCBEB3E33D46B026 /* Build configuration list for PBXNativeTarget "web3swift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E651976B70BE86932EA87F2B9AD68978 /* Debug */,
+				14F49199D3CC1E3B81464D3C5F935647 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3433,11 +3701,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		3C80AB3B961D90D843CA153F965A2A92 /* Build configuration list for PBXNativeTarget "web3swift" */ = {
+		427F0F003A1AD80AE00155AFCDEFAC20 /* Build configuration list for PBXNativeTarget "Alamofire" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9EA5AE8B6FE433F7BEB76F17396B1538 /* Debug */,
-				A67A26674D797D31BE32D03798456392 /* Release */,
+				BC26ACE7A8E469B7CB4DF93AB98ED9BA /* Debug */,
+				11501F35A84F5D7DD09552223A70AEB4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3451,6 +3719,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		542923B6169AB32229C59B5B570D63AF /* Build configuration list for PBXNativeTarget "scrypt" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5FFBE88AFE3EB1D3D9317E7F0E40B582 /* Debug */,
+				386B844D06A5C35F1E8F677124FB0F8E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		64983011E689E8B1A79C910DC9586585 /* Build configuration list for PBXNativeTarget "BigInt" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -3460,56 +3737,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		72AC1961BBF15FD368891C98E1ACC3E6 /* Build configuration list for PBXNativeTarget "secp256k1_ios" */ = {
+		D0637060A33DEA8F8FFA737800C2EBA6 /* Build configuration list for PBXNativeTarget "Pods-DiveLane" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				EAC3556ACB9158C696605F6DF7FED0F7 /* Debug */,
-				6B58B970FA89C62260ECAC051331AD7E /* Release */,
+				C2515876189680EFF27B6D630974AD4A /* Debug */,
+				4D965340994D321A83197A205B0723C1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		75E1137F2D55F8FF45B7A9DAA708E38E /* Build configuration list for PBXNativeTarget "PromiseKit" */ = {
+		D71A113F7FB614887B8B56A9A86FF3DF /* Build configuration list for PBXNativeTarget "secp256k1_ios" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				55AEA2E47B7BEE4513E0FCD92DBDD630 /* Debug */,
-				F99145997395F97BC5A56174A456C867 /* Release */,
+				01F77B74955626F69D0E3B75A610BDAE /* Debug */,
+				5B5F3D56B70FB451B5DA18DCE290A04A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		75F63FEEE333FA09AADF0045B3600E41 /* Build configuration list for PBXNativeTarget "Pods-DiveLane" */ = {
+		F608F46F694DF62068D4455B9780A34D /* Build configuration list for PBXNativeTarget "PromiseKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				95709AAE2A614AA06746949C0AABE592 /* Debug */,
-				2A88E0C397165D2CC4151BB5EF9E3E77 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		A528ABCD5D9EB3DE7A3EECD4E532BEA7 /* Build configuration list for PBXNativeTarget "scrypt" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				16D0EAFCC4CEA1F4901988E9BB1CAAF1 /* Debug */,
-				5AA4687AC371136C1B0F3BDB8DE09826 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CF9B47EABDC4081F8981B500A2DA1363 /* Build configuration list for PBXNativeTarget "Result" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BB96DA7328FD9B6D9E5AF5F02A4CC254 /* Debug */,
-				DE30D0A5850A6DDEFCCBD94E1E96D979 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		E3EB2D11C364DFB8BCE43D56ADCEA2C8 /* Build configuration list for PBXNativeTarget "QRCodeReader.swift" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				36C53686462EB409C25AFED3AFFF2F49 /* Debug */,
-				2AD0DAEFB2B084E43E601375030D32E1 /* Release */,
+				A248860FC512D02CEB6B77967405B5C6 /* Debug */,
+				FDD442AB08C54E819E788A01F9F01229 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Pods/Target Support Files/Pods-DiveLane/Pods-DiveLane-acknowledgements.markdown
+++ b/Pods/Target Support Files/Pods-DiveLane/Pods-DiveLane-acknowledgements.markdown
@@ -1,6 +1,29 @@
 # Acknowledgements
 This application makes use of the following third party libraries:
 
+## Alamofire
+
+Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 ## BigInt
 
 

--- a/Pods/Target Support Files/Pods-DiveLane/Pods-DiveLane-acknowledgements.plist
+++ b/Pods/Target Support Files/Pods-DiveLane/Pods-DiveLane-acknowledgements.plist
@@ -14,6 +14,35 @@
 		</dict>
 		<dict>
 			<key>FooterText</key>
+			<string>Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+</string>
+			<key>License</key>
+			<string>MIT</string>
+			<key>Title</key>
+			<string>Alamofire</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
 			<string>
 Copyright (c) 2016-2017 Károly Lőrentey
 

--- a/Pods/Target Support Files/Pods-DiveLane/Pods-DiveLane-frameworks.sh
+++ b/Pods/Target Support Files/Pods-DiveLane/Pods-DiveLane-frameworks.sh
@@ -143,6 +143,7 @@ strip_invalid_archs() {
 
 
 if [[ "$CONFIGURATION" == "Debug" ]]; then
+  install_framework "${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework"
   install_framework "${BUILT_PRODUCTS_DIR}/BigInt/BigInt.framework"
   install_framework "${BUILT_PRODUCTS_DIR}/CryptoSwift/CryptoSwift.framework"
   install_framework "${BUILT_PRODUCTS_DIR}/PromiseKit/PromiseKit.framework"
@@ -154,6 +155,7 @@ if [[ "$CONFIGURATION" == "Debug" ]]; then
   install_framework "${BUILT_PRODUCTS_DIR}/web3swift/web3swift.framework"
 fi
 if [[ "$CONFIGURATION" == "Release" ]]; then
+  install_framework "${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework"
   install_framework "${BUILT_PRODUCTS_DIR}/BigInt/BigInt.framework"
   install_framework "${BUILT_PRODUCTS_DIR}/CryptoSwift/CryptoSwift.framework"
   install_framework "${BUILT_PRODUCTS_DIR}/PromiseKit/PromiseKit.framework"


### PR DESCRIPTION
In this PR, I added _Alamofire_ library to the project, and I migrated 4 _URLSession_ methods to _Alamofire_ in these classes: 

- EtherscanService
- FiatService
- TokensService
- TransactionsHistoryService

New _Alamofire_ methods replaced old _URLSession_ methods, and I didn't move them to a separate class due to my confusion I explained here:
https://github.com/matterinc/DiveLane/issues/40#issuecomment-426878555

The new code with _Alamofire_ methods implemented works  in the same way as the code from `develop` branch works.