### PR TITLE
Add pending transactions to TransactionHistory view

### DIFF
--- a/Franklin/PresentationLayer/SendMoney/ViewControllers/SendMoneyVC+Actions.swift
+++ b/Franklin/PresentationLayer/SendMoney/ViewControllers/SendMoneyVC+Actions.swift
@@ -49,7 +49,8 @@ extension SendMoneyController {
                                                            gasLimit: .manual(BigUInt(120000)),
                                                            gasPrice: .manual(BigUInt(1100000000)))
                 let password = try wallet.getPassword()
-                _ = try wallet.sendTx(transaction: tx, options: nil, password: password)
+                let txResult = try wallet.sendTx(transaction: tx, options: nil, password: password)
+                try self.saveTransaction(wallet: wallet, value: amount, txResult: txResult, token: token)
                 self.showReady(animated: true)
             } catch let error {
                 self.alerts.showErrorAlert(for: self, error: "Error occurred: \(error.localizedDescription)", completion: { [unowned self] in
@@ -74,7 +75,8 @@ extension SendMoneyController {
                                                      gasLimit: .manual(BigUInt(120000)),
                                                      gasPrice: .manual(BigUInt(15000000000)))
                 let password = try wallet.getPassword()
-                _ = try wallet.sendTx(transaction: tx, options: nil, password: password)
+                let txResult = try wallet.sendTx(transaction: tx, options: nil, password: password)
+                try self.saveTransaction(wallet: wallet, value: amount, txResult: txResult, token: nil)
                 self.showReady(animated: true)
             } catch let error {
                 self.alerts.showErrorAlert(for: self, error: "Error occurred: \(error.localizedDescription)", completion: { [unowned self] in
@@ -95,7 +97,8 @@ extension SendMoneyController {
                                                       value: amount,
                                                       gasLimit: .manual(BigUInt(120000)),
                                                       gasPrice: .manual(BigUInt(1100000000)))
-                _ = try wallet.sendTx(transaction: tx, options: nil, password: password)
+                let txResult = try wallet.sendTx(transaction: tx, options: nil, password: password)
+                try self.saveTransaction(wallet: wallet, value: amount, txResult: txResult, token: nil)
                 self.showReady(animated: true)
             } catch let error {
                 self.alerts.showErrorAlert(for: self, error: "Error occurred: \(error.localizedDescription)", completion: { [unowned self] in
@@ -103,5 +106,18 @@ extension SendMoneyController {
                 })
             }
         }
+    }
+    
+    internal func saveTransaction(wallet: Wallet, value: String, txResult: TransactionSendingResult, token: ERC20Token?) throws {
+        let transaction = ETHTransaction(transactionHash: txResult.hash,
+                                         from: txResult.transaction.sender!.address,
+                                         to: txResult.transaction.to.address,
+                                         amount: value,
+                                         date: Date.init(),
+                                         data: txResult.transaction.data,
+                                         token: token,
+                                         networkId: CurrentNetwork.currentNetwork.id,
+                                         isPending: true)
+        try wallet.save(transactions: [transaction])
     }
 }

--- a/Franklin/PresentationLayer/TransactionsHistory/ViewControllers/TransactionsHistoryViewController.swift
+++ b/Franklin/PresentationLayer/TransactionsHistory/ViewControllers/TransactionsHistoryViewController.swift
@@ -195,6 +195,9 @@ class TransactionsHistoryViewController: BasicViewController {
         if let erc20Txs = try? wallet.loadERC20Transactions(txType: .erc20, network: net) {
             txs += erc20Txs
         }
+        if let pendingTxs = try? wallet.loadPendingTransactions(network: net) {
+            txs += pendingTxs
+        }
         
 //        guard let pendingTxs = try? wallet.loadTransactionsPool() else {
 //            prepareTransactionsForView(transactions: txs)


### PR DESCRIPTION
# Description

Add pending transactions to TransactionHistory view. The feature is included for ETH, ERC20 or xDAI transactions. Implementation approach includes:


* Store all sent transactions on the `ETHTransactionModel` with `isPending=true`. 
* When the `TransactionHistory` view refreshes:
1. fetch pending ETHTransactionModel records. Then for each transaction:
1. Get transaction details using txHash and web3
1. Update the record status on those that were already confirmed
1. trxs that are still pending are appended to the view list

Refs #56 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules